### PR TITLE
fix logic for adding subcategories, fix issues with deleting subcategories

### DIFF
--- a/src/components/ManageCategories/AddSubcategoryModal.vue
+++ b/src/components/ManageCategories/AddSubcategoryModal.vue
@@ -21,6 +21,11 @@ const { newSubcategoriesValue, addSubcategory, error } = useAddSubcategory(
   subcategoriesAdded,
 )
 
+async function handleAddSubcategory() {
+  await addSubcategory()
+  closeAddSubcategoryModal()
+}
+
 function closeAddSubcategoryModal() {
   isOpen.value = false
 }
@@ -29,7 +34,7 @@ function closeAddSubcategoryModal() {
 <template>
   <Modal :is-modal-open="isOpen" @modal-closed="closeAddSubcategoryModal">
     <Input type="text" placeholder="Subcategory name" v-model="newSubcategoriesValue" />
-    <button @click="addSubcategory">Save Subcategory</button>
+    <button @click="handleAddSubcategory">Save Subcategory</button>
     <Error v-if="error" :error="error" />
   </Modal>
 </template>

--- a/src/components/ManageCategories/CategoryView.vue
+++ b/src/components/ManageCategories/CategoryView.vue
@@ -58,6 +58,7 @@ const error = deleteCategoryError || deleteSubcategoryError
       </span>
     </div>
     <SubcategoryView
+      v-if="showSubcategories"
       :subcategories="subcategories"
       @subcategory-delete-clicked="deleteSubcategory"
     />

--- a/src/components/ManageCategories/hooks/useAddSubcategory.ts
+++ b/src/components/ManageCategories/hooks/useAddSubcategory.ts
@@ -1,3 +1,5 @@
+import { splitString } from '@/helpers/splitString'
+import { addNewSubcategories } from '@/service/categories/addNewSubcategories'
 import type { Category } from '@/types/expenseData'
 import { ref, type Ref } from 'vue'
 
@@ -13,14 +15,12 @@ export function useAddSubcategory(
   const error = ref<Error | undefined>(undefined)
   async function addSubcategory() {
     try {
-      const newSubcategories = newSubcategoriesValue.value
-        .split(',')
-        .map((subcategory) => subcategory.trim())
-        .filter((subcategory) => !subcategory)
-      if (newSubcategories.length === 0) {
-        alert('Please enter at least one subcategory.')
-        return
+      const newSubcategories = splitString(newSubcategoriesValue.value)
+      if (!newSubcategories) {
+        throw new Error('Subcategory name cannot be empty')
       }
+      const orderedSubcategories = newSubcategories.sort((a, b) => a.localeCompare(b))
+      await addNewSubcategories(category, orderedSubcategories)
 
       subcategoryAddedCallback(newSubcategories)
     } catch (err) {

--- a/src/helpers/splitString.ts
+++ b/src/helpers/splitString.ts
@@ -1,0 +1,17 @@
+export function splitString(
+  str: string,
+  separator: string = ',',
+  options: {
+    removeEmpty?: boolean
+  } = { removeEmpty: true },
+): string[] | undefined {
+  const trimmedValue = str.trim()
+  if (trimmedValue === '') {
+    return undefined
+  }
+  const splitValues = trimmedValue.split(separator).map((value) => value.trim())
+  if (options?.removeEmpty) {
+    return splitValues.filter((value) => value.length > 0)
+  }
+  return splitValues
+}

--- a/src/service/categories/deleteSubcategory.ts
+++ b/src/service/categories/deleteSubcategory.ts
@@ -1,11 +1,13 @@
 import { editCategory } from '@/repository/categories/editCategory'
+import { getCategories } from '@/repository/categories/getCategories'
 import type { Category } from '@/types/expenseData'
 
 export async function deleteSubcategory(
   category: Category,
   subcategoryToDelete: string,
 ): Promise<Category> {
-  const newSubcategories = category.subcategories.filter(
+  const upToDateCategory = await getCategory(category.name)
+  const newSubcategories = upToDateCategory.subcategories.filter(
     (subcategory) => subcategory !== subcategoryToDelete,
   )
   const newCategory = {
@@ -13,4 +15,13 @@ export async function deleteSubcategory(
     subcategories: newSubcategories,
   }
   return await editCategory(newCategory as Category)
+}
+
+async function getCategory(categoryName: string): Promise<Category> {
+  const categories = await getCategories()
+  const category = categories.find((category) => category.name === categoryName)
+  if (!category) {
+    throw new Error(`Category ${categoryName} not found`)
+  }
+  return category
 }


### PR DESCRIPTION
- Adding subcategories was always adding an empty string because the split string logic was resolving to an empty array
- When deleting multiple subcategories it was using the subcategories on the Category object which was stale because of the way that the subcategories logic is managed. To fix first pull the latest category based on name (the unique identitfier for categories) and then delete the subcategory from the latest data

Closes #18 