### PR TITLE
fix: recalculate netAmount when amount or paidBackAmount is updated

### DIFF
--- a/packages/backend/src/expense/__tests__/service/updateExpenseService.test.ts
+++ b/packages/backend/src/expense/__tests__/service/updateExpenseService.test.ts
@@ -36,4 +36,55 @@ describe('updateExpenseService', () => {
     // Assert
     expect(result).toEqual(expect.objectContaining({ ...fakeRepoResult, amount: 3.0 }))
   })
+
+  it('should recalculate netAmount from amount and paidBackAmount', async () => {
+    // Arrange
+    const input = {
+      id: 'abc',
+      userId: 'u1',
+      accountId: 'a1',
+      amount: 10.0,
+      paidBackAmount: 3.0,
+      netAmount: 99.99, // stale value — should be ignored
+    } as UpdateExpenseInput
+    const fakeRepoResult = { id: 'abc', amount: 1000, paidBackAmount: 300, netAmount: 700 }
+    mockedUpdateExpenseRepository.mockResolvedValueOnce(fakeRepoResult)
+
+    // Act
+    await updateExpenseService(input)
+
+    // Assert
+    expect(mockedUpdateExpenseRepository).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fieldsToUpdate: expect.objectContaining({
+          amount: 1000,
+          paidBackAmount: 300,
+          netAmount: 700,
+        }),
+      }),
+    )
+  })
+
+  it('should not overwrite netAmount when amount is not provided', async () => {
+    // Arrange
+    const input = {
+      id: 'abc',
+      userId: 'u1',
+      accountId: 'a1',
+      paidBackAmount: 2.0,
+      // amount is undefined — cannot recalculate
+    } as UpdateExpenseInput
+    const fakeRepoResult = { id: 'abc', paidBackAmount: 200 }
+    mockedUpdateExpenseRepository.mockResolvedValueOnce(fakeRepoResult)
+
+    // Act
+    await updateExpenseService(input)
+
+    // Assert
+    expect(mockedUpdateExpenseRepository).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fieldsToUpdate: expect.not.objectContaining({ netAmount: expect.anything() }),
+      }),
+    )
+  })
 })

--- a/packages/backend/src/expense/service/updateExpenseService.ts
+++ b/packages/backend/src/expense/service/updateExpenseService.ts
@@ -5,12 +5,18 @@ import { convertDbAmountToDecimals } from './helpers/convertDbAmountToDecimals'
 
 export async function updateExpenseService(input: UpdateExpenseInput) {
   const { id, accountId: _accountId, ...otherFields } = input
+
+  const computedNetAmount =
+    input.amount !== undefined && input.paidBackAmount !== undefined
+      ? input.amount - input.paidBackAmount
+      : input.netAmount
+
   const fieldsToUpdate = {
     ...otherFields,
     ...convertDomainAmountToInteger({
       amount: input.amount,
       paidBackAmount: input.paidBackAmount,
-      netAmount: input.netAmount,
+      netAmount: computedNetAmount,
     }),
     updatedAt: new Date(),
   }

--- a/packages/frontend/src/components/ExpenseDataTable/ExpenseDataTable.vue
+++ b/packages/frontend/src/components/ExpenseDataTable/ExpenseDataTable.vue
@@ -105,6 +105,13 @@ async function handleCellUpdate(rowIndex: number, key: keyof DisplayExpense, val
         ...updatedExpense,
         [key]: value,
       }
+
+      if (key === 'amount' || key === 'paidBackAmount') {
+        updatedExpense = {
+          ...updatedExpense,
+          netAmount: (updatedExpense.amount ?? 0) - (updatedExpense.paidBackAmount ?? 0),
+        }
+      }
     }
 
     // Update via service

--- a/packages/frontend/src/components/ExpenseDataTable/hooks/__tests__/useUpdateExpense.test.ts
+++ b/packages/frontend/src/components/ExpenseDataTable/hooks/__tests__/useUpdateExpense.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
+import type { Expense } from '@/types/expenseData'
+import { useManageExpense } from '../useUpdateExpense'
+import { updateExpense as serviceUpdateExpense } from '@/service/expenses/updateExpense'
+
+// inject is used inside useManageExpense to get the popover ref — mocked here to avoid
+// Vue's "inject() can only be used inside setup()" warning in a non-component test context
+vi.mock('vue', async (importOriginal) => {
+  const vue = await importOriginal<typeof import('vue')>()
+  return { ...vue, inject: vi.fn().mockReturnValue(undefined) }
+})
+
+vi.mock('@/service/expenses/updateExpense', () => ({
+  updateExpense: vi.fn(),
+}))
+
+vi.mock('@/service/expenses/deleteExpense', () => ({
+  deleteExpense: vi.fn(),
+}))
+
+const fakeCreatedAt = new Date('2026-01-01T00:00:00.000Z')
+
+const fakeExpense: Expense = {
+  id: 'fake-id',
+  userId: 'fake-user-id',
+  accountId: 'fake-account-id',
+  name: 'Coffee',
+  amount: 10,
+  paidBackAmount: 0,
+  netAmount: 10,
+  date: '2026-01-15',
+  createdAt: fakeCreatedAt,
+  updatedAt: fakeCreatedAt,
+}
+
+describe('useManageExpense', () => {
+  const mockedServiceUpdateExpense = serviceUpdateExpense as Mock
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockedServiceUpdateExpense.mockResolvedValue(undefined)
+  })
+
+  describe('when updating paidBackAmount', () => {
+    it('should recalculate netAmount as amount minus new paidBackAmount', async () => {
+      // Arrange
+      const { updateExpense, expenseData } = useManageExpense(fakeExpense, vi.fn(), vi.fn())
+
+      // Act
+      await updateExpense(3, 'paidBackAmount')
+
+      // Assert
+      expect(expenseData.value.netAmount).toBe(7)
+      expect(expenseData.value.paidBackAmount).toBe(3)
+    })
+
+    it('should send the recalculated netAmount to the service', async () => {
+      // Arrange
+      const { updateExpense } = useManageExpense(fakeExpense, vi.fn(), vi.fn())
+
+      // Act
+      await updateExpense(3, 'paidBackAmount')
+
+      // Assert
+      expect(mockedServiceUpdateExpense).toHaveBeenCalledWith(
+        expect.objectContaining({ paidBackAmount: 3, netAmount: 7 }),
+      )
+    })
+  })
+
+  describe('when updating amount', () => {
+    it('should recalculate netAmount as new amount minus paidBackAmount', async () => {
+      // Arrange
+      const expenseWithPaidBack = { ...fakeExpense, amount: 10, paidBackAmount: 2, netAmount: 8 }
+      const { updateExpense, expenseData } = useManageExpense(expenseWithPaidBack, vi.fn(), vi.fn())
+
+      // Act
+      await updateExpense(15, 'amount')
+
+      // Assert
+      expect(expenseData.value.netAmount).toBe(13)
+      expect(expenseData.value.amount).toBe(15)
+    })
+  })
+
+  describe('when updating a non-amount field', () => {
+    it('should not change netAmount', async () => {
+      // Arrange
+      const { updateExpense, expenseData } = useManageExpense(fakeExpense, vi.fn(), vi.fn())
+
+      // Act
+      await updateExpense('New name', 'name')
+
+      // Assert
+      expect(expenseData.value.netAmount).toBe(10)
+      expect(expenseData.value.name).toBe('New name')
+    })
+  })
+
+  describe('when value has not changed', () => {
+    it('should not call the service', async () => {
+      // Arrange
+      const { updateExpense } = useManageExpense(fakeExpense, vi.fn(), vi.fn())
+
+      // Act — paidBackAmount is already 0
+      await updateExpense(0, 'paidBackAmount')
+
+      // Assert
+      expect(mockedServiceUpdateExpense).not.toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
netAmount was never recomputed on expense update, causing the dashboard to display the original amount instead of the net amount after paid back values were recorded.