### PR TITLE
feat(frontend): sticky tabs/duplicates row and table headers on Add Data page (SPE-111)

### DIFF
--- a/.claude/plans/SPE-111.md
+++ b/.claude/plans/SPE-111.md
@@ -61,7 +61,7 @@ framework" today.
   - The `--spacing-*` namespace generates spacing-scale utilities (`top-nav`, `h-nav`, `p-nav`, etc. all resolve to 60px). The `--z-index-*` namespace generates `z-nav`, `z-sticky-secondary`, `z-table-header`.
   - This makes the nav height and the sticky layer ordering a single source of truth — future changes (e.g. nav bar grows to 64px, or a 4th sticky layer is added) are one-line edits here.
 
-- [ ] **Step 2: Update `NavigationBar.vue` to use the new tokens**
+- [x] **Step 2: Update `NavigationBar.vue` to use the new tokens**
   - Replace the static `h-15` (line 36) and the conditional `'fixed top-0 left-0 right-0 bg-white z-50 px-7.5 h-15'` (line 37) with `h-nav` and `z-nav` respectively (`top-0`/`left-0`/`right-0` stay as-is since they anchor to the viewport, not the nav height).
 
 - [ ] **Step 3: Update `App.vue` to use the new token**

--- a/.claude/plans/SPE-111.md
+++ b/.claude/plans/SPE-111.md
@@ -91,7 +91,7 @@ framework" today.
   - Import `useScrollPast` from `@/helpers/hooks/useScrollPast` (already used by `TableHeaders.vue` and `NavigationBar.vue`).
   - `const { hasScrolledPast: hasTabsRowScrolledPast } = useScrollPast(tabsRowRef)`.
 
-- [ ] **Step 9: Apply conditional sticky classes to the tabs/duplicates row**
+- [x] **Step 9: Apply conditional sticky classes to the tabs/duplicates row**
   - Mirror the `TableHeaders.vue` pattern — keep existing classes and conditionally add sticky styling when `hasTabsRowScrolledPast` is true:
     ```html
     :class="{ 'sticky top-nav z-sticky-secondary bg-white py-2': hasTabsRowScrolledPast }"

--- a/.claude/plans/SPE-111.md
+++ b/.claude/plans/SPE-111.md
@@ -64,7 +64,7 @@ framework" today.
 - [x] **Step 2: Update `NavigationBar.vue` to use the new tokens**
   - Replace the static `h-15` (line 36) and the conditional `'fixed top-0 left-0 right-0 bg-white z-50 px-7.5 h-15'` (line 37) with `h-nav` and `z-nav` respectively (`top-0`/`left-0`/`right-0` stay as-is since they anchor to the viewport, not the nav height).
 
-- [ ] **Step 3: Update `App.vue` to use the new token**
+- [x] **Step 3: Update `App.vue` to use the new token**
   - Replace `flex-none h-15` (line 42) with `flex-none h-nav`.
 
 - [ ] **Step 4: Update `TableHeaders.vue` to use the new z-index token**

--- a/.claude/plans/SPE-111.md
+++ b/.claude/plans/SPE-111.md
@@ -72,7 +72,7 @@ framework" today.
 
 ### Part B — Sticky tabs/duplicates row + dynamic table header offset
 
-- [ ] **Step 5: Add a reusable `useElementHeight` composable**
+- [x] **Step 5: Add a reusable `useElementHeight` composable**
   - New file: `packages/frontend/src/helpers/hooks/useElementHeight.ts`.
   - Signature: `useElementHeight(elementRef: Ref<HTMLElement | null>): Ref<number>`.
   - Implementation: use a `ResizeObserver` (observe/unobserve on mount/unmount) to keep a reactive `height` ref in sync with `elementRef.value.offsetHeight` (or `getBoundingClientRect().height`). Returns `0` while the ref is unset.

--- a/.claude/plans/SPE-111.md
+++ b/.claude/plans/SPE-111.md
@@ -87,7 +87,7 @@ framework" today.
   - Add `ref="tabsRowRef"` to the existing `<div class="flex items-start justify-between">` (around line 268) containing `<TabViewNav>` and the "Duplicates" `<Button>`.
   - Declare `const tabsRowRef = ref<HTMLElement | null>(null)`.
 
-- [ ] **Step 8: Reuse `useScrollPast` for the tabs/duplicates row**
+- [x] **Step 8: Reuse `useScrollPast` for the tabs/duplicates row**
   - Import `useScrollPast` from `@/helpers/hooks/useScrollPast` (already used by `TableHeaders.vue` and `NavigationBar.vue`).
   - `const { hasScrolledPast: hasTabsRowScrolledPast } = useScrollPast(tabsRowRef)`.
 

--- a/.claude/plans/SPE-111.md
+++ b/.claude/plans/SPE-111.md
@@ -78,7 +78,7 @@ framework" today.
   - Implementation: use a `ResizeObserver` (observe/unobserve on mount/unmount) to keep a reactive `height` ref in sync with `elementRef.value.offsetHeight` (or `getBoundingClientRect().height`). Returns `0` while the ref is unset.
   - This is intentionally generic/small so any future sticky-stack page can measure its own layers the same way.
 
-- [ ] **Step 6: Add a `getThemeSpacingPx` helper**
+- [x] **Step 6: Add a `getThemeSpacingPx` helper**
   - New file: `packages/frontend/src/helpers/css/getThemeSpacingPx.ts` (or co-locate under `helpers/hooks` if preferred for consistency).
   - Signature: `getThemeSpacingPx(tokenName: string): number` — reads `getComputedStyle(document.documentElement).getPropertyValue(`--spacing-${tokenName}`)` and parses the `px` value (Tailwind v4 emits `@theme` values as real CSS custom properties on `:root`).
   - Used to get the nav height (`getThemeSpacingPx('nav')` → `60`) in JS without duplicating the `60` constant from Step 1.

--- a/.claude/plans/SPE-111.md
+++ b/.claude/plans/SPE-111.md
@@ -83,7 +83,7 @@ framework" today.
   - Signature: `getThemeSpacingPx(tokenName: string): number` — reads `getComputedStyle(document.documentElement).getPropertyValue(`--spacing-${tokenName}`)` and parses the `px` value (Tailwind v4 emits `@theme` values as real CSS custom properties on `:root`).
   - Used to get the nav height (`getThemeSpacingPx('nav')` → `60`) in JS without duplicating the `60` constant from Step 1.
 
-- [ ] **Step 7: Wrap the tabs/duplicates row with a template ref in `AddDataView.vue`**
+- [x] **Step 7: Wrap the tabs/duplicates row with a template ref in `AddDataView.vue`**
   - Add `ref="tabsRowRef"` to the existing `<div class="flex items-start justify-between">` (around line 268) containing `<TabViewNav>` and the "Duplicates" `<Button>`.
   - Declare `const tabsRowRef = ref<HTMLElement | null>(null)`.
 

--- a/.claude/plans/SPE-111.md
+++ b/.claude/plans/SPE-111.md
@@ -118,7 +118,7 @@ framework" today.
   - `AddExpenseTable.vue` / `AddIncomeTable.vue`: add optional prop `stickyTopOffsetPx?: number`, forward to their `<GenericTable>` usage.
   - `AddDataView.vue`: pass `:sticky-top-offset-px="tableHeaderStickyTopPx"` (Step 10) to both `<AddExpenseTable>` and `<AddIncomeTable>`.
 
-- [ ] **Step 13: Verify stacking order / z-index**
+- [x] **Step 13: Verify stacking order / z-index**
   - Confirm final stacking order top-to-bottom and z-index high-to-low:
     1. `NavigationBar` — `fixed`, `z-nav` (50), 0–60px
     2. Tabs/Duplicates row — `sticky`, `z-sticky-secondary` (45), 60px–(60 + rowHeight)px

--- a/.claude/plans/SPE-111.md
+++ b/.claude/plans/SPE-111.md
@@ -100,7 +100,7 @@ framework" today.
   - `bg-white` prevents table rows from showing through once the row overlays content (same reason `TableHeaders.vue` adds `bg-white` only when stuck).
   - Verify visually whether horizontal padding (`-mx-5 px-5` or similar, to counteract `App.vue`'s `.flex-1.p-5`) is needed so the sticky row's background spans full width. `position: sticky` keeps the element within its parent's box, so this may not be necessary — confirm in Step 13.
 
-- [ ] **Step 10: Measure the tabs/duplicates row height and compute the table header offset**
+- [x] **Step 10: Measure the tabs/duplicates row height and compute the table header offset**
   - `const tabsRowHeightPx = useElementHeight(tabsRowRef)` (Step 5's composable).
   - `const navHeightPx = getThemeSpacingPx('nav')` (Step 6's helper) — only needs to be read once (e.g. on mount), since the token value won't change at runtime.
   - `const tableHeaderStickyTopPx = computed(() => navHeightPx + tabsRowHeightPx.value)`.

--- a/.claude/plans/SPE-111.md
+++ b/.claude/plans/SPE-111.md
@@ -113,7 +113,7 @@ framework" today.
     - When `hasScrolledPast` is true and `stickyTopOffsetPx` is **not** provided, apply `top-nav z-table-header bg-white h-11 align-bottom` via class (current default behavior, now using the Part A token).
   - This keeps the default (`top-nav`) for every other table on the site, while letting the Add Data page override with a measured pixel value.
 
-- [ ] **Step 12: Thread `stickyTopOffsetPx` through `GenericTable.vue` → `AddExpenseTable.vue` / `AddIncomeTable.vue` → `AddDataView.vue`**
+- [x] **Step 12: Thread `stickyTopOffsetPx` through `GenericTable.vue` → `AddExpenseTable.vue` / `AddIncomeTable.vue` → `AddDataView.vue`**
   - `GenericTable.vue`: add optional prop `stickyTopOffsetPx?: number`, pass through to `<TableHeaders :sticky-top-offset-px="stickyTopOffsetPx" ... />`.
   - `AddExpenseTable.vue` / `AddIncomeTable.vue`: add optional prop `stickyTopOffsetPx?: number`, forward to their `<GenericTable>` usage.
   - `AddDataView.vue`: pass `:sticky-top-offset-px="tableHeaderStickyTopPx"` (Step 10) to both `<AddExpenseTable>` and `<AddIncomeTable>`.

--- a/.claude/plans/SPE-111.md
+++ b/.claude/plans/SPE-111.md
@@ -106,7 +106,7 @@ framework" today.
   - `const tableHeaderStickyTopPx = computed(() => navHeightPx + tabsRowHeightPx.value)`.
   - This replaces a hardcoded "measure it once in devtools and bake in a pixel value" approach with a value that stays correct if the row's rendered height changes.
 
-- [ ] **Step 11: Make `TableHeaders.vue`'s sticky top offset configurable**
+- [x] **Step 11: Make `TableHeaders.vue`'s sticky top offset configurable**
   - Add an optional prop `stickyTopOffsetPx?: number`.
   - Update the `<th>` binding so that:
     - When `hasScrolledPast` is true and `stickyTopOffsetPx` is provided, apply `z-table-header bg-white h-11 align-bottom` via class, and set `top: ${stickyTopOffsetPx}px` via an inline `:style` binding.

--- a/.claude/plans/SPE-111.md
+++ b/.claude/plans/SPE-111.md
@@ -67,7 +67,7 @@ framework" today.
 - [x] **Step 3: Update `App.vue` to use the new token**
   - Replace `flex-none h-15` (line 42) with `flex-none h-nav`.
 
-- [ ] **Step 4: Update `TableHeaders.vue` to use the new z-index token**
+- [x] **Step 4: Update `TableHeaders.vue` to use the new z-index token**
   - Replace `z-40` in the conditional class (line 24) with `z-table-header`. (The `top-15` part is handled in Part B below.)
 
 ### Part B — Sticky tabs/duplicates row + dynamic table header offset

--- a/.claude/plans/SPE-111.md
+++ b/.claude/plans/SPE-111.md
@@ -1,0 +1,134 @@
+# Plan: SPE-111 — Make expense/income tabs and duplicates button on "Add Data" page sticky
+
+## Overview
+
+On `AddDataView.vue`, the row containing the Expenses/Income tabs (`TabViewNav`) and the
+"Duplicates" button currently scrolls out of view once the user has added enough rows.
+We want this row to become "stuck" between the navigation bar and the (already sticky)
+table headers, mirroring the existing sticky pattern used by `NavigationBar.vue` and
+`TableHeaders.vue`, both of which use the shared `useScrollPast` hook.
+
+**Current stacking reference points:**
+- `NavigationBar.vue`: becomes `fixed top-0 left-0 right-0 z-50 h-15` (60px tall) once `hasScrolledPast` is true.
+- `TableHeaders.vue` (`<th>`): becomes `sticky top-15 z-40 bg-white h-11 align-bottom` (top offset 60px) once `hasScrolledPast` is true.
+
+**New element stacking goal:**
+- Tabs/Duplicates row becomes `sticky` + `bg-white` once `hasScrolledPast` is true, positioned directly below the fixed nav bar and above the table header's stacking layer.
+- Table header's sticky `top` offset must then be pushed down by the height of this new row so the two stuck elements stack vertically instead of overlapping.
+
+Alongside the feature itself, this plan also folds in two small refactors to make the
+sticky-layer values easier to maintain going forward:
+
+1. **Centralize the shared layout constants (nav height, z-index layers) as Tailwind v4
+   `@theme` tokens** instead of repeating raw values (`h-15`, `top-15`, `z-50`, `z-40`)
+   across components.
+2. **Replace the hardcoded pixel guess for the table header's offset with a small,
+   reusable "measure this element's height" composable**, scoped to `AddDataView.vue`
+   for now, so the offset stays correct even if the tabs/duplicates row's height
+   changes (responsive layout, indicator dot, etc.).
+
+Both are written generically enough that a future page needing its own 2–3 layer sticky
+stack can reuse the same primitives without us building a full generic "sticky stack
+framework" today.
+
+## Files to change
+
+- `packages/frontend/src/assets/base.css` — add `@theme` tokens for nav height and sticky z-index layers.
+- `packages/frontend/src/components/NavigationBar/NavigationBar.vue` — use the new `h-nav`/`top-nav`/`z-nav` tokens in place of `h-15`/`z-50`.
+- `packages/frontend/src/App.vue` — use `h-nav` in place of `h-15` for the nav bar's flex container.
+- `packages/frontend/src/components/TableHeaders.vue` — use `z-table-header` token; accept an optional dynamic `stickyTopOffsetPx` prop (falls back to the `top-nav` token when not provided).
+- `packages/frontend/src/components/DesignSystem/Table/GenericTable.vue` — thread the new `stickyTopOffsetPx` prop down to `TableHeaders`.
+- `packages/frontend/src/components/AddExpenseTable/AddExpenseTable.vue` and `AddIncomeTable.vue` — pass `stickyTopOffsetPx` down to `GenericTable` (only these two consumers need it, since they are only rendered on the Add Data page).
+- `packages/frontend/src/views/AddDataView.vue` — make the tabs/duplicates row sticky; measure its height and compute the table header offset.
+- New: `packages/frontend/src/helpers/hooks/useElementHeight.ts` — small reusable composable returning a reactive element height (via `ResizeObserver`).
+- New: `packages/frontend/src/helpers/css/getThemeSpacingPx.ts` (or similar) — small helper to read a `--spacing-*` theme token's pixel value from `:root` at runtime.
+- No changes needed to `ExpenseDataTable.vue`, `IncomeDataTable.vue`, or `DuplicateReviewModal.vue` — they keep using `TableHeaders`'s default (`top-nav`) offset.
+
+## Steps
+
+### Part A — Centralize shared layout constants as Tailwind `@theme` tokens
+
+- [x] **Step 1: Add `@theme` tokens to `base.css`**
+  - In `packages/frontend/src/assets/base.css` (which already does `@import 'tailwindcss';`), add:
+    ```css
+    @theme {
+      --spacing-nav: 60px; /* nav bar height; was previously hardcoded as h-15 / top-15 */
+      --z-index-nav: 50;             /* NavigationBar, when fixed */
+      --z-index-sticky-secondary: 45; /* tabs/duplicates row, when stuck */
+      --z-index-table-header: 40;     /* table <th>, when stuck */
+    }
+    ```
+  - The `--spacing-*` namespace generates spacing-scale utilities (`top-nav`, `h-nav`, `p-nav`, etc. all resolve to 60px). The `--z-index-*` namespace generates `z-nav`, `z-sticky-secondary`, `z-table-header`.
+  - This makes the nav height and the sticky layer ordering a single source of truth — future changes (e.g. nav bar grows to 64px, or a 4th sticky layer is added) are one-line edits here.
+
+- [ ] **Step 2: Update `NavigationBar.vue` to use the new tokens**
+  - Replace the static `h-15` (line 36) and the conditional `'fixed top-0 left-0 right-0 bg-white z-50 px-7.5 h-15'` (line 37) with `h-nav` and `z-nav` respectively (`top-0`/`left-0`/`right-0` stay as-is since they anchor to the viewport, not the nav height).
+
+- [ ] **Step 3: Update `App.vue` to use the new token**
+  - Replace `flex-none h-15` (line 42) with `flex-none h-nav`.
+
+- [ ] **Step 4: Update `TableHeaders.vue` to use the new z-index token**
+  - Replace `z-40` in the conditional class (line 24) with `z-table-header`. (The `top-15` part is handled in Part B below.)
+
+### Part B — Sticky tabs/duplicates row + dynamic table header offset
+
+- [ ] **Step 5: Add a reusable `useElementHeight` composable**
+  - New file: `packages/frontend/src/helpers/hooks/useElementHeight.ts`.
+  - Signature: `useElementHeight(elementRef: Ref<HTMLElement | null>): Ref<number>`.
+  - Implementation: use a `ResizeObserver` (observe/unobserve on mount/unmount) to keep a reactive `height` ref in sync with `elementRef.value.offsetHeight` (or `getBoundingClientRect().height`). Returns `0` while the ref is unset.
+  - This is intentionally generic/small so any future sticky-stack page can measure its own layers the same way.
+
+- [ ] **Step 6: Add a `getThemeSpacingPx` helper**
+  - New file: `packages/frontend/src/helpers/css/getThemeSpacingPx.ts` (or co-locate under `helpers/hooks` if preferred for consistency).
+  - Signature: `getThemeSpacingPx(tokenName: string): number` — reads `getComputedStyle(document.documentElement).getPropertyValue(`--spacing-${tokenName}`)` and parses the `px` value (Tailwind v4 emits `@theme` values as real CSS custom properties on `:root`).
+  - Used to get the nav height (`getThemeSpacingPx('nav')` → `60`) in JS without duplicating the `60` constant from Step 1.
+
+- [ ] **Step 7: Wrap the tabs/duplicates row with a template ref in `AddDataView.vue`**
+  - Add `ref="tabsRowRef"` to the existing `<div class="flex items-start justify-between">` (around line 268) containing `<TabViewNav>` and the "Duplicates" `<Button>`.
+  - Declare `const tabsRowRef = ref<HTMLElement | null>(null)`.
+
+- [ ] **Step 8: Reuse `useScrollPast` for the tabs/duplicates row**
+  - Import `useScrollPast` from `@/helpers/hooks/useScrollPast` (already used by `TableHeaders.vue` and `NavigationBar.vue`).
+  - `const { hasScrolledPast: hasTabsRowScrolledPast } = useScrollPast(tabsRowRef)`.
+
+- [ ] **Step 9: Apply conditional sticky classes to the tabs/duplicates row**
+  - Mirror the `TableHeaders.vue` pattern — keep existing classes and conditionally add sticky styling when `hasTabsRowScrolledPast` is true:
+    ```html
+    :class="{ 'sticky top-nav z-sticky-secondary bg-white py-2': hasTabsRowScrolledPast }"
+    ```
+  - `top-nav` / `z-sticky-secondary` come from the Part A tokens — directly under the fixed nav bar, between the nav bar's `z-nav` (50) and the table header's `z-table-header` (40).
+  - `bg-white` prevents table rows from showing through once the row overlays content (same reason `TableHeaders.vue` adds `bg-white` only when stuck).
+  - Verify visually whether horizontal padding (`-mx-5 px-5` or similar, to counteract `App.vue`'s `.flex-1.p-5`) is needed so the sticky row's background spans full width. `position: sticky` keeps the element within its parent's box, so this may not be necessary — confirm in Step 13.
+
+- [ ] **Step 10: Measure the tabs/duplicates row height and compute the table header offset**
+  - `const tabsRowHeightPx = useElementHeight(tabsRowRef)` (Step 5's composable).
+  - `const navHeightPx = getThemeSpacingPx('nav')` (Step 6's helper) — only needs to be read once (e.g. on mount), since the token value won't change at runtime.
+  - `const tableHeaderStickyTopPx = computed(() => navHeightPx + tabsRowHeightPx.value)`.
+  - This replaces a hardcoded "measure it once in devtools and bake in a pixel value" approach with a value that stays correct if the row's rendered height changes.
+
+- [ ] **Step 11: Make `TableHeaders.vue`'s sticky top offset configurable**
+  - Add an optional prop `stickyTopOffsetPx?: number`.
+  - Update the `<th>` binding so that:
+    - When `hasScrolledPast` is true and `stickyTopOffsetPx` is provided, apply `z-table-header bg-white h-11 align-bottom` via class, and set `top: ${stickyTopOffsetPx}px` via an inline `:style` binding.
+    - When `hasScrolledPast` is true and `stickyTopOffsetPx` is **not** provided, apply `top-nav z-table-header bg-white h-11 align-bottom` via class (current default behavior, now using the Part A token).
+  - This keeps the default (`top-nav`) for every other table on the site, while letting the Add Data page override with a measured pixel value.
+
+- [ ] **Step 12: Thread `stickyTopOffsetPx` through `GenericTable.vue` → `AddExpenseTable.vue` / `AddIncomeTable.vue` → `AddDataView.vue`**
+  - `GenericTable.vue`: add optional prop `stickyTopOffsetPx?: number`, pass through to `<TableHeaders :sticky-top-offset-px="stickyTopOffsetPx" ... />`.
+  - `AddExpenseTable.vue` / `AddIncomeTable.vue`: add optional prop `stickyTopOffsetPx?: number`, forward to their `<GenericTable>` usage.
+  - `AddDataView.vue`: pass `:sticky-top-offset-px="tableHeaderStickyTopPx"` (Step 10) to both `<AddExpenseTable>` and `<AddIncomeTable>`.
+
+- [ ] **Step 13: Verify stacking order / z-index**
+  - Confirm final stacking order top-to-bottom and z-index high-to-low:
+    1. `NavigationBar` — `fixed`, `z-nav` (50), 0–60px
+    2. Tabs/Duplicates row — `sticky`, `z-sticky-secondary` (45), 60px–(60 + rowHeight)px
+    3. Table headers — `sticky`, `z-table-header` (40), (60 + rowHeight)px onward
+  - Double-check no element creates a new stacking context (e.g. via `transform`/`opacity` on an ancestor) that would break `z-index` comparisons across these three elements.
+
+## Potential issues / things to watch for
+
+- **Tailwind v4 `@theme` token assumptions**: confirm `--spacing-*` and `--z-index-*` custom theme keys generate the expected `top-nav`/`h-nav`/`z-nav`-style utilities in the installed Tailwind v4 version, and that theme values are emitted as real `:root` CSS custom properties (required for `getThemeSpacingPx` in Step 6 to work). If not, fall back to exporting the nav height as a plain TS constant shared between CSS (via an arbitrary value `top-[var(--nav-height)]`) and JS.
+- **`useScrollPast` independence**: each call tracks its own element's `offsetTop` independently. Since `position: sticky` doesn't remove elements from normal flow, adding sticky styles to the tabs row shouldn't shift the `offsetTop` measured by `TableHeaders.vue`'s own `useScrollPast` call.
+- **Horizontal padding/background bleed**: the tabs/duplicates row lives inside `App.vue`'s `.flex-1.p-5` content container. Once stuck, `bg-white` may show the container's padding as a visible inset unless extra horizontal padding/negative margin is applied — verify visually rather than guessing (Step 9/13).
+- **`mb-5` on `TabViewNav`**: `TabViewNav.vue` has `mb-5` baked into its root `<div>`, which currently provides spacing below the tab row. Once the parent row becomes `sticky`/overlaying, check this margin doesn't create an unwanted gap or collapse oddly against the sticky table header.
+- **`ResizeObserver` timing**: `useElementHeight` won't have a value until after the first observed resize callback fires (typically on mount). Ensure `tableHeaderStickyTopPx` has a sensible default (e.g. `navHeightPx` alone, i.e. `tabsRowHeightPx` starting at `0`) so there's no flash of incorrectly-positioned table header before the first measurement.

--- a/.claude/skills/mapChangesMade/SKILL.md
+++ b/.claude/skills/mapChangesMade/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: mapChangesMade
+description: Produce a visual map of how the files changed so far in this session fit together — component/prop hierarchy, data/runtime flow, and a file index with each file's role. Use when the user is getting lost in a multi-file change and wants to see the big picture.
+---
+
+# Map Changes Made
+
+Produce a "you are here" map of the changes made so far in the current session (or, if the
+user specifies a commit range/branch, of that diff instead). The goal is to help the user
+re-orient across a multi-file change, not to re-explain individual diffs line-by-line.
+
+## How to gather the change set
+
+1. Default to the files touched in this conversation so far (edits/writes you made).
+2. If the user references commits/a branch instead, use `git diff <range> --stat` /
+   `git log` to enumerate the changed files.
+3. Don't include incidental files (lockfiles, generated output) in the diagrams below
+   unless they're central to the change.
+
+## What to produce
+
+Build whichever of these sections are relevant to the change — skip ones that don't apply
+rather than forcing every change into all three shapes:
+
+1. **Hierarchy / call graph** — if the change threads a prop, value, or dependency through
+   several files (e.g. parent component → child → child → leaf), draw that chain as a tree
+   showing which files are pure pass-throughs vs. where the real logic lives (compute vs.
+   consume).
+
+2. **Runtime data flow** — if the change involves computed/derived values, hooks, or
+   reactive state flowing between files, draw an arrow-diagram: `source file ──► value
+   ──► where it's consumed ──► what it controls`. Name the actual variables/functions
+   involved so it's grep-able.
+
+3. **Visual/spatial layout** — if the change affects UI layout, stacking, or positioning
+   (z-index, sticky elements, layout regions), draw an ASCII box diagram of how the pieces
+   stack or sit relative to each other on screen, annotated with the relevant
+   classes/values from the code.
+
+4. **File index table** — always include a compact table: `| File | Role |` — one row per
+   changed file, each role described in terms of the diagrams above (e.g. "owns the
+   computation", "pure pass-through", "consumes the value and applies styling").
+
+## Style notes
+
+- Use real file paths (relative to repo root) and real identifier names from the code —
+  this should be grep-able/navigable, not abstract.
+- Keep diagrams plain ASCII (box-drawing characters are fine) so they render in a terminal.
+- Be concise — this is a map, not documentation. Prefer diagrams over prose.
+- If a helper/hook is shared with other parts of the codebase beyond this change, note
+  what else uses it, but don't deep-dive into unrelated call sites.

--- a/packages/frontend/src/App.vue
+++ b/packages/frontend/src/App.vue
@@ -39,7 +39,7 @@ function toggleManageCategories() {
 
 <template>
   <div class="flex min-h-screen flex-col">
-    <div class="flex-none h-15">
+    <div class="flex-none h-nav">
       <NavigationBar
         v-if="isLoggedIn"
         :is-logged-in="isLoggedIn"

--- a/packages/frontend/src/assets/base.css
+++ b/packages/frontend/src/assets/base.css
@@ -1,5 +1,12 @@
 @import 'tailwindcss';
 
+@theme {
+  --spacing-nav: 60px; /* nav bar height; was previously hardcoded as h-15 / top-15 */
+  --z-index-nav: 50; /* NavigationBar, when fixed */
+  --z-index-sticky-secondary: 45; /* tabs/duplicates row, when stuck */
+  --z-index-table-header: 40; /* table <th>, when stuck */
+}
+
 html {
   margin: 0;
   padding: 0 30px 0 30px;

--- a/packages/frontend/src/components/AddExpenseTable/AddExpenseTable.vue
+++ b/packages/frontend/src/components/AddExpenseTable/AddExpenseTable.vue
@@ -17,6 +17,7 @@ import { watch } from 'vue'
 const newExpenses = defineModel<NewExpense[]>({ required: true })
 const props = defineProps<{
   beforeSaveExpense?: () => Promise<boolean>
+  stickyTopOffsetPx?: number
 }>()
 const store = getStore()
 
@@ -323,6 +324,7 @@ const tableActions: TableAction[] = [
     :error="error"
     :loading="isLoading"
     mode="editable"
+    :sticky-top-offset-px="props.stickyTopOffsetPx"
     @cell:changed="handleCellUpdate"
   />
 </template>

--- a/packages/frontend/src/components/AddIncomeTable/AddIncomeTable.vue
+++ b/packages/frontend/src/components/AddIncomeTable/AddIncomeTable.vue
@@ -15,6 +15,7 @@ import { DateFormat, formatDate } from '@/helpers/date/formatDate'
 const newIncomes = defineModel<NewIncome[]>({ required: true })
 const props = defineProps<{
   beforeSaveIncome?: () => Promise<boolean>
+  stickyTopOffsetPx?: number
 }>()
 const store = getStore()
 
@@ -225,6 +226,7 @@ const tableActions: TableAction[] = [
     :error="error"
     :loading="isLoading"
     mode="editable"
+    :sticky-top-offset-px="props.stickyTopOffsetPx"
     @cell:changed="handleCellUpdate"
   />
 </template>

--- a/packages/frontend/src/components/DesignSystem/TabViewNav/TabViewNav.vue
+++ b/packages/frontend/src/components/DesignSystem/TabViewNav/TabViewNav.vue
@@ -14,7 +14,7 @@ const emit = defineEmits<{
 }>()
 </script>
 <template>
-  <div class="border border-gray-300 rounded-t-md w-fit mb-5">
+  <div class="flex items-center border border-gray-300 rounded-t-md w-fit">
     <Button
       v-for="tab of tabs"
       :key="tab.value"

--- a/packages/frontend/src/components/DesignSystem/Table/GenericTable.vue
+++ b/packages/frontend/src/components/DesignSystem/Table/GenericTable.vue
@@ -22,6 +22,7 @@ const props = withDefaults(
     initialRowCount?: number
     rowChunkSize?: number
     rowKey?: RowKeyResolver<T>
+    stickyTopOffsetPx?: number
   }>(),
   {
     rowActions: () => [],
@@ -33,6 +34,7 @@ const props = withDefaults(
     initialRowCount: undefined,
     rowChunkSize: undefined,
     rowKey: undefined,
+    stickyTopOffsetPx: undefined,
   },
 )
 
@@ -115,7 +117,7 @@ function getRowKey(row: T, index: number): string | number {
 <template>
   <div>
     <table class="w-full table-fixed mb-5">
-      <TableHeaders :headers="headers" />
+      <TableHeaders :headers="headers" :sticky-top-offset-px="stickyTopOffsetPx" />
       <tbody>
         <TableRow
           v-for="(row, index) in visibleData"

--- a/packages/frontend/src/components/NavigationBar/NavigationBar.vue
+++ b/packages/frontend/src/components/NavigationBar/NavigationBar.vue
@@ -33,8 +33,8 @@ const navigationLinks = [
 <template>
   <div
     ref="navigationRef"
-    class="flex-none flex h-15 justify-between items-center bg-white"
-    :class="{ 'fixed top-0 left-0 right-0 bg-white z-50 px-7.5 h-15': hasScrolledPast }"
+    class="flex-none flex h-nav justify-between items-center bg-white"
+    :class="{ 'fixed top-0 left-0 right-0 bg-white z-nav px-7.5 h-nav': hasScrolledPast }"
   >
     <div class="flex gap-7.5">
       <RouterLink

--- a/packages/frontend/src/components/TableHeaders.vue
+++ b/packages/frontend/src/components/TableHeaders.vue
@@ -5,12 +5,13 @@ import { useScrollPast } from '@/helpers/hooks/useScrollPast'
 const theadRef = ref<HTMLElement | null>(null)
 const { hasScrolledPast } = useScrollPast(theadRef)
 
-const { headers } = defineProps<{
+const { headers, stickyTopOffsetPx } = defineProps<{
   headers: {
     label: string
     required?: boolean
     customClass?: string
   }[]
+  stickyTopOffsetPx?: number
 }>()
 </script>
 
@@ -21,7 +22,14 @@ const { headers } = defineProps<{
         v-for="(header, index) in headers"
         :key="index"
         class="sticky"
-        :class="[header.customClass, { 'top-15 z-table-header bg-white h-11 align-bottom': hasScrolledPast }]"
+        :class="[
+          header.customClass,
+          {
+            'z-table-header bg-white h-11 align-bottom': hasScrolledPast,
+            'top-nav': hasScrolledPast && stickyTopOffsetPx === undefined,
+          },
+        ]"
+        :style="hasScrolledPast && stickyTopOffsetPx !== undefined ? { top: `${stickyTopOffsetPx}px` } : undefined"
       >
         {{ header.label }} <span v-if="header.required" class="text-red-700 text-2xl">*</span>
       </th>

--- a/packages/frontend/src/components/TableHeaders.vue
+++ b/packages/frontend/src/components/TableHeaders.vue
@@ -1,9 +1,9 @@
 <script lang="ts" setup>
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { useScrollPast } from '@/helpers/hooks/useScrollPast'
+import { getThemeSpacingPx } from '@/helpers/css/getThemeSpacingPx'
 
 const theadRef = ref<HTMLElement | null>(null)
-const { hasScrolledPast } = useScrollPast(theadRef)
 
 const { headers, stickyTopOffsetPx } = defineProps<{
   headers: {
@@ -13,6 +13,9 @@ const { headers, stickyTopOffsetPx } = defineProps<{
   }[]
   stickyTopOffsetPx?: number
 }>()
+
+const stickyTopPx = computed(() => stickyTopOffsetPx ?? getThemeSpacingPx('nav'))
+const { hasScrolledPast } = useScrollPast(theadRef, { triggerOffsetPx: stickyTopPx })
 </script>
 
 <template>
@@ -26,10 +29,9 @@ const { headers, stickyTopOffsetPx } = defineProps<{
           header.customClass,
           {
             'z-table-header bg-white min-h-11 align-bottom': hasScrolledPast,
-            'top-nav': hasScrolledPast && stickyTopOffsetPx === undefined,
           },
         ]"
-        :style="hasScrolledPast && stickyTopOffsetPx !== undefined ? { top: `${stickyTopOffsetPx}px` } : undefined"
+        :style="{ top: `${stickyTopPx}px` }"
       >
         {{ header.label }} <span v-if="header.required" class="text-red-700 text-2xl">*</span>
       </th>

--- a/packages/frontend/src/components/TableHeaders.vue
+++ b/packages/frontend/src/components/TableHeaders.vue
@@ -25,7 +25,7 @@ const { headers, stickyTopOffsetPx } = defineProps<{
         :class="[
           header.customClass,
           {
-            'z-table-header bg-white h-11 align-bottom': hasScrolledPast,
+            'z-table-header bg-white min-h-11 align-bottom': hasScrolledPast,
             'top-nav': hasScrolledPast && stickyTopOffsetPx === undefined,
           },
         ]"

--- a/packages/frontend/src/components/TableHeaders.vue
+++ b/packages/frontend/src/components/TableHeaders.vue
@@ -21,7 +21,7 @@ const { headers } = defineProps<{
         v-for="(header, index) in headers"
         :key="index"
         class="sticky"
-        :class="[header.customClass, { 'top-15 z-40 bg-white h-11 align-bottom': hasScrolledPast }]"
+        :class="[header.customClass, { 'top-15 z-table-header bg-white h-11 align-bottom': hasScrolledPast }]"
       >
         {{ header.label }} <span v-if="header.required" class="text-red-700 text-2xl">*</span>
       </th>

--- a/packages/frontend/src/helpers/css/getThemeSpacingPx.ts
+++ b/packages/frontend/src/helpers/css/getThemeSpacingPx.ts
@@ -1,0 +1,14 @@
+const PX_UNIT_REGEX = /px$/
+const FALLBACK_PX = 0
+
+export function getThemeSpacingPx(tokenName: string): number {
+  const value = getComputedStyle(document.documentElement)
+    .getPropertyValue(`--spacing-${tokenName}`)
+    .trim()
+
+  if (!PX_UNIT_REGEX.test(value)) {
+    return FALLBACK_PX
+  }
+
+  return Number.parseFloat(value)
+}

--- a/packages/frontend/src/helpers/hooks/useElementHeight.ts
+++ b/packages/frontend/src/helpers/hooks/useElementHeight.ts
@@ -16,7 +16,7 @@ export function useElementHeight(elementRef: Ref<HTMLElement | null>) {
     resizeObserver = new ResizeObserver(([entry]) => {
       height.value = entry.borderBoxSize?.[0]?.blockSize ?? entry.target.getBoundingClientRect().height
     })
-    resizeObserver.observe(elementRef.value)
+    resizeObserver.observe(elementRef.value, { box: 'border-box' })
   })
 
   onUnmounted(() => {

--- a/packages/frontend/src/helpers/hooks/useElementHeight.ts
+++ b/packages/frontend/src/helpers/hooks/useElementHeight.ts
@@ -1,0 +1,27 @@
+import { onMounted, onUnmounted, ref, type Ref } from 'vue'
+
+const ZERO_HEIGHT_PX = 0
+
+export function useElementHeight(elementRef: Ref<HTMLElement | null>) {
+  const height = ref(ZERO_HEIGHT_PX)
+  let resizeObserver: ResizeObserver | null = null
+
+  onMounted(() => {
+    if (!elementRef.value) {
+      return
+    }
+
+    height.value = elementRef.value.offsetHeight
+
+    resizeObserver = new ResizeObserver(([entry]) => {
+      height.value = entry.borderBoxSize?.[0]?.blockSize ?? entry.target.getBoundingClientRect().height
+    })
+    resizeObserver.observe(elementRef.value)
+  })
+
+  onUnmounted(() => {
+    resizeObserver?.disconnect()
+  })
+
+  return height
+}

--- a/packages/frontend/src/helpers/hooks/useScrollPast.ts
+++ b/packages/frontend/src/helpers/hooks/useScrollPast.ts
@@ -1,7 +1,7 @@
-import { onMounted, onUnmounted, ref, type Ref } from 'vue'
+import { onMounted, onUnmounted, ref, toValue, watch, type MaybeRefOrGetter, type Ref } from 'vue'
 
 type UseScrollPastOptions = {
-  triggerOffsetPx?: number
+  triggerOffsetPx?: MaybeRefOrGetter<number>
 }
 
 export function useScrollPast(
@@ -21,10 +21,14 @@ export function useScrollPast(
     }
 
     const scrollPosition = window.scrollY || window.pageYOffset
-    const scrollThreshold = initialOffsetTop.value - triggerOffsetPx
+    const scrollThreshold = initialOffsetTop.value - toValue(triggerOffsetPx)
 
     hasScrolledPast.value = scrollPosition > scrollThreshold
   }
+
+  // Re-check when the trigger offset itself changes (e.g. a sticky element
+  // above this one resizes), not just on scroll/mount.
+  watch(() => toValue(triggerOffsetPx), checkScrollPosition)
 
   onMounted(() => {
     checkScrollPosition()

--- a/packages/frontend/src/views/AddDataView.vue
+++ b/packages/frontend/src/views/AddDataView.vue
@@ -12,6 +12,8 @@ import { formatPastedBankData } from '@/helpers/bankInfoFormatting/formatPastedB
 import { DataType } from '@/helpers/bankInfoFormatting/bankInfoTypes'
 import { useControlModal } from '@/components/DesignSystem/Modal/useControlModal'
 import { useScrollPast } from '@/helpers/hooks/useScrollPast'
+import { useElementHeight } from '@/helpers/hooks/useElementHeight'
+import { getThemeSpacingPx } from '@/helpers/css/getThemeSpacingPx'
 
 const TAB_EXPENSE = 'expense'
 const TAB_INCOME = 'income'
@@ -32,6 +34,9 @@ const store = getStore()
 const currentTab = ref<typeof TAB_EXPENSE | typeof TAB_INCOME>(TAB_EXPENSE)
 const tabsRowRef = ref<HTMLElement | null>(null)
 const { hasScrolledPast: hasTabsRowScrolledPast } = useScrollPast(tabsRowRef)
+const tabsRowHeightPx = useElementHeight(tabsRowRef)
+const navHeightPx = getThemeSpacingPx('nav')
+const tableHeaderStickyTopPx = computed(() => navHeightPx + tabsRowHeightPx.value)
 const {
   isModalOpen: isDuplicatesModalOpen,
   openModal: openDuplicatesModal,

--- a/packages/frontend/src/views/AddDataView.vue
+++ b/packages/frontend/src/views/AddDataView.vue
@@ -11,6 +11,7 @@ import { getStore } from '@/store/store'
 import { formatPastedBankData } from '@/helpers/bankInfoFormatting/formatPastedBankData'
 import { DataType } from '@/helpers/bankInfoFormatting/bankInfoTypes'
 import { useControlModal } from '@/components/DesignSystem/Modal/useControlModal'
+import { useScrollPast } from '@/helpers/hooks/useScrollPast'
 
 const TAB_EXPENSE = 'expense'
 const TAB_INCOME = 'income'
@@ -30,6 +31,7 @@ const formatDataPlaceholder = 'Paste your bank data here. Copy it directly from 
 const store = getStore()
 const currentTab = ref<typeof TAB_EXPENSE | typeof TAB_INCOME>(TAB_EXPENSE)
 const tabsRowRef = ref<HTMLElement | null>(null)
+const { hasScrolledPast: hasTabsRowScrolledPast } = useScrollPast(tabsRowRef)
 const {
   isModalOpen: isDuplicatesModalOpen,
   openModal: openDuplicatesModal,

--- a/packages/frontend/src/views/AddDataView.vue
+++ b/packages/frontend/src/views/AddDataView.vue
@@ -268,7 +268,11 @@ function removeIncomeDuplicateDraftRow(draftIndex: number) {
       @paste.prevent="handlePaste"
     />
   </div>
-  <div ref="tabsRowRef" class="flex items-start justify-between">
+  <div
+    ref="tabsRowRef"
+    class="flex items-start justify-between"
+    :class="{ 'sticky top-nav z-sticky-secondary bg-white py-2': hasTabsRowScrolledPast }"
+  >
     <TabViewNav :tabs="addDataTabs" :current-tab="currentTab" @tab-clicked="handleMainTabClick" />
     <Button
       type="primary"

--- a/packages/frontend/src/views/AddDataView.vue
+++ b/packages/frontend/src/views/AddDataView.vue
@@ -293,6 +293,7 @@ function removeIncomeDuplicateDraftRow(draftIndex: number) {
     <AddExpenseTable
       v-model="store.newExpenses.value"
       :before-save-expense="beforeSaveExpense"
+      :sticky-top-offset-px="tableHeaderStickyTopPx"
       @move-to-income="moveToIncome"
     />
   </div>
@@ -300,6 +301,7 @@ function removeIncomeDuplicateDraftRow(draftIndex: number) {
     <AddIncomeTable
       v-model="store.newIncomes.value"
       :before-save-income="beforeSaveIncome"
+      :sticky-top-offset-px="tableHeaderStickyTopPx"
       @move-to-expense="moveToExpense"
     />
   </div>

--- a/packages/frontend/src/views/AddDataView.vue
+++ b/packages/frontend/src/views/AddDataView.vue
@@ -29,6 +29,7 @@ const formatDataPlaceholder = 'Paste your bank data here. Copy it directly from 
 
 const store = getStore()
 const currentTab = ref<typeof TAB_EXPENSE | typeof TAB_INCOME>(TAB_EXPENSE)
+const tabsRowRef = ref<HTMLElement | null>(null)
 const {
   isModalOpen: isDuplicatesModalOpen,
   openModal: openDuplicatesModal,
@@ -265,7 +266,7 @@ function removeIncomeDuplicateDraftRow(draftIndex: number) {
       @paste.prevent="handlePaste"
     />
   </div>
-  <div class="flex items-start justify-between">
+  <div ref="tabsRowRef" class="flex items-start justify-between">
     <TabViewNav :tabs="addDataTabs" :current-tab="currentTab" @tab-clicked="handleMainTabClick" />
     <Button
       type="primary"

--- a/packages/frontend/src/views/AddDataView.vue
+++ b/packages/frontend/src/views/AddDataView.vue
@@ -33,9 +33,11 @@ const formatDataPlaceholder = 'Paste your bank data here. Copy it directly from 
 const store = getStore()
 const currentTab = ref<typeof TAB_EXPENSE | typeof TAB_INCOME>(TAB_EXPENSE)
 const tabsRowRef = ref<HTMLElement | null>(null)
-const { hasScrolledPast: hasTabsRowScrolledPast } = useScrollPast(tabsRowRef)
-const tabsRowHeightPx = useElementHeight(tabsRowRef)
 const navHeightPx = getThemeSpacingPx('nav')
+const { hasScrolledPast: hasTabsRowScrolledPast } = useScrollPast(tabsRowRef, {
+  triggerOffsetPx: navHeightPx,
+})
+const tabsRowHeightPx = useElementHeight(tabsRowRef)
 const tableHeaderStickyTopPx = computed(() => navHeightPx + tabsRowHeightPx.value)
 const {
   isModalOpen: isDuplicatesModalOpen,

--- a/packages/frontend/src/views/AddDataView.vue
+++ b/packages/frontend/src/views/AddDataView.vue
@@ -277,7 +277,7 @@ function removeIncomeDuplicateDraftRow(draftIndex: number) {
   </div>
   <div
     ref="tabsRowRef"
-    class="flex items-start justify-between"
+    class="flex items-center justify-between"
     :class="{ 'sticky top-nav z-sticky-secondary bg-white py-2': hasTabsRowScrolledPast }"
   >
     <TabViewNav :tabs="addDataTabs" :current-tab="currentTab" @tab-clicked="handleMainTabClick" />

--- a/packages/frontend/vitest.setup.ts
+++ b/packages/frontend/vitest.setup.ts
@@ -1,1 +1,9 @@
 import '@testing-library/jest-dom/vitest'
+
+class ResizeObserverMock implements ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+globalThis.ResizeObserver ??= ResizeObserverMock


### PR DESCRIPTION
## Summary
  - Introduce Tailwind v4 `@theme` tokens (`--spacing-nav`, `--z-index-nav`, `--z-index-sticky-secondary`,
  `--z-index-table-header`) so the nav bar height and sticky layer z-indexes are centralized and reusable.
  - Make the tabs/duplicates row on the Add Data page stick below the nav bar once scrolled, and make the table header
  row stick below that.
  - Compute the table header's sticky offset dynamically (nav height + live-measured tabs row height) via a new
  `useElementHeight` composable, instead of a hardcoded pixel value.
  - Fix `useScrollPast` so each sticky layer's "stuck" styling triggers at its actual stuck position (not the viewport
  top), eliminating a visual overlap/clipping bug between the tabs row and table header.
  - Allow the sticky table header cell to grow (`min-h-11`) for multi-line column labels instead of clipping them.
  - Vertically center the tabs/duplicates row and the tabs within `TabViewNav`.
  - Add a `mapChangesMade` skill for visualizing multi-file change sets in future sessions.