### PR TITLE
feat(table): disable subCategory dropdown until category is selected

### DIFF
--- a/.claude/plans/SPE-113.md
+++ b/.claude/plans/SPE-113.md
@@ -111,8 +111,8 @@ is the correct gate.
 
 ### 4. `ExpenseDataTable.vue` — same change
 
-- [ ] Find the `subCategory` column definition (around line 186–194).
-- [ ] Add:
+- [x] Find the `subCategory` column definition (around line 186–194).
+- [x] Add:
 
 ```ts
 {

--- a/.claude/plans/SPE-113.md
+++ b/.claude/plans/SPE-113.md
@@ -1,0 +1,171 @@
+# SPE-113: Disable subCategory dropdown until category is selected
+
+## Problem
+
+In `AddExpenseTable` and `ExpenseDataTable`, the subCategory dropdown is always
+interactive even when no category is selected. Because subcategory options are
+derived from the selected category, opening the dropdown yields an empty list —
+a confusing UX. The generic table must not hardcode this business rule.
+
+## Approach decision
+
+The existing `ColumnConfig` interface already supports a row-function pattern for
+`dropdownOptions: string[] | ((row: T) => string[])`. The same pattern fits here:
+add a `disabled?: boolean | ((row: T) => boolean)` field to `ColumnConfig`. Each
+page (AddExpenseTable, ExpenseDataTable) supplies the rule as a row function, so
+the generic table stays generic.
+
+This is preferred over:
+- Hardcoding `category`/`subCategory` key detection in the generic table (violates
+  the stated constraint).
+- Overloading `editable` to be row-aware (editable is a static per-column flag and
+  changes its semantics mid-stream).
+
+---
+
+## Files to change
+
+| File | Change |
+|---|---|
+| `src/components/DesignSystem/Table/types.ts` | Add `disabled` field to `ColumnConfig` |
+| `src/components/DesignSystem/Table/TableCell.vue` | Read `disabled` in `isEditable` computed |
+| `src/components/AddExpenseTable/AddExpenseTable.vue` | Pass `disabled` on subCategory column |
+| `src/components/ExpenseDataTable/ExpenseDataTable.vue` | Pass `disabled` on subCategory column |
+| `src/components/DesignSystem/Table/__tests__/TableCell.test.ts` | Test disabled behavior |
+
+---
+
+## Implementation steps
+
+### 1. `types.ts` — extend `ColumnConfig`
+
+- [x] Add `disabled?: boolean | ((row: T) => boolean)` to the `ColumnConfig<T>`
+  interface, after the existing `editable` field.
+
+```ts
+// types.ts (line ~14)
+editable?: boolean
+disabled?: boolean | ((row: T) => boolean)   // ← add
+```
+
+No other types need changing; `RowAction.show` already uses the same pattern and
+serves as precedent.
+
+---
+
+### 2. `TableCell.vue` — respect `disabled` in `isEditable`
+
+- [ ] Extend the `isEditable` computed (currently lines 117–121) to evaluate the
+  new `disabled` field **after** the existing checks:
+
+```ts
+const isEditable = computed(() => {
+  if (props.mode === 'view') return false
+  if (props.column.calculate) return false
+  if (props.column.editable === false) return false   // rename existing final line
+
+  const disabled = props.column.disabled
+  if (typeof disabled === 'function') {
+    return !disabled(props.row)
+  }
+  return !disabled
+})
+```
+
+- [ ] No template changes are needed: when `isEditable` is `false` the existing
+  `<p>` view-mode branch renders, which is the correct disabled visual.
+
+**Edge cases:**
+- `disabled` is `undefined` → treated as `false` → cell remains editable (no
+  behaviour change for existing consumers).
+- `disabled` is `true` (static) → always non-editable, same as `editable: false`
+  (different intent but same rendering; the field name communicates "temporarily
+  off" vs. "permanently off").
+- `disabled` returns `true` for some rows but `false` for others → per-row
+  reactivity is handled automatically because `props.row` is reactive and the
+  computed re-evaluates.
+
+---
+
+### 3. `AddExpenseTable.vue` — disable subCategory when no category
+
+- [ ] Find the `subCategory` entry in the `columns` computed (around line 238–246).
+- [ ] Add:
+
+```ts
+{
+  key: 'subCategory',
+  label: 'Subcategory',
+  type: 'dropdown',
+  required: false,
+  dropdownOptions: (row: DisplayExpense) =>
+    getSubcategories(getCategoryId(row.category)),
+  disabled: (row: DisplayExpense) => !row.category,  // ← add
+},
+```
+
+`row.category` holds the display name string; falsy when empty/undefined, which
+is the correct gate.
+
+---
+
+### 4. `ExpenseDataTable.vue` — same change
+
+- [ ] Find the `subCategory` column definition (around line 186–194).
+- [ ] Add:
+
+```ts
+{
+  key: 'subCategory',
+  label: 'Subcategory',
+  type: 'dropdown',
+  dropdownOptions: (row: DisplayExpense) => {
+    const category = getCategory(row.category)
+    return getSubcategories(category?.id)
+  },
+  disabled: (row: DisplayExpense) => !row.category,  // ← add
+},
+```
+
+---
+
+### 5. Tests — `TableCell.test.ts`
+
+- [ ] Add a `describe('when column.disabled is set')` block covering:
+
+  - **Static `disabled: true`**: mount in `editable` mode, assert `<p>` is
+    rendered and `Input`/`DropdownWithInput` is absent.
+  - **Static `disabled: false`**: assert normal editable rendering (regression
+    guard).
+  - **Function `disabled: (row) => !row.category` with `row.category` empty**:
+    assert cell renders as view mode.
+  - **Function `disabled: (row) => !row.category` with `row.category` set**:
+    assert dropdown is rendered.
+
+  Use the existing `mountTableCell` / `createColumn` helpers already in the file.
+
+- [ ] No new test files are needed; existing `GenericTable.test.ts` and
+  `DropdownWithInput.test.ts` do not need changes (behaviour of those components
+  is unchanged).
+
+---
+
+## What is NOT changing
+
+- `DropdownWithInput.vue`, `Select.vue`, `DropdownOptions.vue` — no disabled
+  prop needed; the cell simply won't render the dropdown when disabled.
+- `GenericTable.vue`, `TableRow.vue` — no awareness of `disabled` needed;
+  `TableCell` is the only consumer.
+- The category-clearing logic in both tables (when category changes, subCategory
+  is cleared) remains unchanged and is not part of this ticket.
+
+---
+
+## Edge cases
+
+| Scenario | Expected behaviour |
+|---|---|
+| User selects a category, then clears it | subCategory cell becomes view-mode (disabled); displayed value is the previously stored subCategory text (not cleared by this feature) |
+| Row is in view mode | Already non-editable regardless of `disabled`; no change |
+| `disabled` function throws | Vue computed error — keep the function simple and guard against undefined |
+| Category column itself | `disabled` is not set on it; always editable |

--- a/.claude/plans/SPE-113.md
+++ b/.claude/plans/SPE-113.md
@@ -89,8 +89,8 @@ const isEditable = computed(() => {
 
 ### 3. `AddExpenseTable.vue` — disable subCategory when no category
 
-- [ ] Find the `subCategory` entry in the `columns` computed (around line 238–246).
-- [ ] Add:
+- [x] Find the `subCategory` entry in the `columns` computed (around line 238–246).
+- [x] Add:
 
 ```ts
 {

--- a/.claude/plans/SPE-113.md
+++ b/.claude/plans/SPE-113.md
@@ -131,7 +131,7 @@ is the correct gate.
 
 ### 5. Tests — `TableCell.test.ts`
 
-- [ ] Add a `describe('when column.disabled is set')` block covering:
+- [x] Add a `describe('when column.disabled is set')` block covering:
 
   - **Static `disabled: true`**: mount in `editable` mode, assert `<p>` is
     rendered and `Input`/`DropdownWithInput` is absent.
@@ -144,7 +144,7 @@ is the correct gate.
 
   Use the existing `mountTableCell` / `createColumn` helpers already in the file.
 
-- [ ] No new test files are needed; existing `GenericTable.test.ts` and
+- [x] No new test files are needed; existing `GenericTable.test.ts` and
   `DropdownWithInput.test.ts` do not need changes (behaviour of those components
   is unchanged).
 

--- a/.claude/plans/SPE-113.md
+++ b/.claude/plans/SPE-113.md
@@ -55,7 +55,7 @@ serves as precedent.
 
 ### 2. `TableCell.vue` — respect `disabled` in `isEditable`
 
-- [ ] Extend the `isEditable` computed (currently lines 117–121) to evaluate the
+- [x] Extend the `isEditable` computed (currently lines 117–121) to evaluate the
   new `disabled` field **after** the existing checks:
 
 ```ts
@@ -72,7 +72,7 @@ const isEditable = computed(() => {
 })
 ```
 
-- [ ] No template changes are needed: when `isEditable` is `false` the existing
+- [x] No template changes are needed: when `isEditable` is `false` the existing
   `<p>` view-mode branch renders, which is the correct disabled visual.
 
 **Edge cases:**

--- a/packages/frontend/src/components/AddExpenseTable/AddExpenseTable.vue
+++ b/packages/frontend/src/components/AddExpenseTable/AddExpenseTable.vue
@@ -277,6 +277,7 @@ const columns = computed<ColumnConfig<DisplayExpense>[]>(() => [
     type: 'dropdown',
     required: false,
     dropdownOptions: (row: DisplayExpense) => getSubcategories(getCategoryId(row.category)),
+    disabled: (row: DisplayExpense) => !row.category,
   },
 ])
 

--- a/packages/frontend/src/components/DesignSystem/Table/TableCell.vue
+++ b/packages/frontend/src/components/DesignSystem/Table/TableCell.vue
@@ -116,8 +116,14 @@ const shouldIncludeUncategorizedOption = computed(() => columnKey === 'category'
 
 const isEditable = computed(() => {
   if (props.mode === 'view') return false
-  if (props.column.calculate) return false // Calculated fields are never editable
-  return props.column.editable !== false
+  if (props.column.calculate) return false
+  if (props.column.editable === false) return false
+
+  const disabled = props.column.disabled
+  if (typeof disabled === 'function') {
+    return !disabled(props.row)
+  }
+  return !disabled
 })
 
 // Debounced emit with 1 second delay

--- a/packages/frontend/src/components/DesignSystem/Table/__tests__/TableCell.test.ts
+++ b/packages/frontend/src/components/DesignSystem/Table/__tests__/TableCell.test.ts
@@ -175,6 +175,59 @@ describe('TableCell', () => {
     })
   })
 
+  describe('when column.disabled is set', () => {
+    it('should render as view mode when disabled is true', () => {
+      const wrapper = mountTableCell({
+        column: createColumn({ key: 'name', label: 'Name', disabled: true }),
+        row: { name: 'Frozen' },
+      })
+
+      expect(wrapper.find('p').exists()).toBe(true)
+      expect(wrapper.find('p').text()).toBe('Frozen')
+      expect(wrapper.findComponent(Input).exists()).toBe(false)
+    })
+
+    it('should remain editable when disabled is false', () => {
+      const wrapper = mountTableCell({
+        column: createColumn({ key: 'name', label: 'Name', disabled: false }),
+        row: { name: 'Editable' },
+      })
+
+      expect(wrapper.findComponent(Input).exists()).toBe(true)
+    })
+
+    it('should render as view mode when disabled function returns true', () => {
+      const wrapper = mountTableCell({
+        column: createColumn({
+          key: 'subCategory',
+          label: 'Subcategory',
+          type: 'dropdown',
+          dropdownOptions: [],
+          disabled: (row) => !row.category,
+        }),
+        row: { subCategory: '', category: '' },
+      })
+
+      expect(wrapper.find('p').exists()).toBe(true)
+      expect(wrapper.findComponent(DropdownWithInput).exists()).toBe(false)
+    })
+
+    it('should render dropdown when disabled function returns false', () => {
+      const wrapper = mountTableCell({
+        column: createColumn({
+          key: 'subCategory',
+          label: 'Subcategory',
+          type: 'dropdown',
+          dropdownOptions: ['Sub1'],
+          disabled: (row) => !row.category,
+        }),
+        row: { subCategory: 'Sub1', category: 'Food' },
+      })
+
+      expect(wrapper.findComponent(DropdownWithInput).exists()).toBe(true)
+    })
+  })
+
   describe('when column type is longtext', () => {
     it('should render Input component with textarea variant', () => {
       const wrapper = mountTableCell({

--- a/packages/frontend/src/components/DesignSystem/Table/types.ts
+++ b/packages/frontend/src/components/DesignSystem/Table/types.ts
@@ -12,6 +12,7 @@ export interface ColumnConfig<T extends TableRowData = TableRowData> {
   type?: CellType
   required?: boolean
   editable?: boolean
+  disabled?: boolean | ((row: T) => boolean)
   customClass?: string
   dropdownOptions?: string[] | ((row: T) => string[])
   format?: (value: unknown, row: T) => string

--- a/packages/frontend/src/components/ExpenseDataTable/ExpenseDataTable.vue
+++ b/packages/frontend/src/components/ExpenseDataTable/ExpenseDataTable.vue
@@ -191,6 +191,7 @@ const columns = computed<ColumnConfig<DisplayExpense>[]>(() => [
       const category = getCategory(row.category)
       return getSubcategories(category?.id)
     },
+    disabled: (row: DisplayExpense) => !row.category,
   },
 ])
 


### PR DESCRIPTION
Description:

  - Add a disabled?: boolean | ((row: T) => boolean) field to ColumnConfig, letting consumers conditionally disable
  individual table cells per row without baking business logic into the generic Table component.
  - Wire TableCell's isEditable check to respect column.disabled (static or per-row function).
  - Use it in AddExpenseTable and ExpenseDataTable to disable the subCategory dropdown whenever no category is
  selected, preventing users from picking a subcategory before a category exists.