### PR TITLE
Close Manage Categories panel on click outside or Escape (SPE-114)

### DIFF
--- a/.claude/plans/SPE-114.md
+++ b/.claude/plans/SPE-114.md
@@ -61,7 +61,7 @@ change.
 
 ## Steps
 
-- [ ] **Step 1: Create the `useClickOutside` composable**
+- [x] **Step 1: Create the `useClickOutside` composable**
   - Location: `packages/frontend/src/helpers/hooks/useClickOutside.ts`, matching the
     existing `helpers/hooks/` composable folder (alongside `useDropdownPosition.ts`).
   - Signature (Composition API, matching `useDropdownPosition.ts`'s style of accepting
@@ -98,13 +98,13 @@ change.
     called with `toRef(props, 'isOpen')` or an inline arrow function — decide in Step 3
     based on what reads cleanest.
 
-- [ ] **Step 2: Add a template ref to `ManageCategories.vue`'s root panel div**
+- [x] **Step 2: Add a template ref to `ManageCategories.vue`'s root panel div**
   - Add `ref="panelRef"` to the `#manage-categories` div
     (`ManageCategories.vue`, the `v-show="isOpen"` div).
   - Declare `const panelRef = ref<HTMLElement | null>(null)` in the `<script setup>`
     block.
 
-- [ ] **Step 3: Wire `useClickOutside` into `ManageCategories.vue`**
+- [x] **Step 3: Wire `useClickOutside` into `ManageCategories.vue`**
   - Import `useClickOutside` from `@/helpers/hooks/useClickOutside`.
   - Call it with the panel ref, an active-check based on `isOpen`, and a callback that
     emits `closeManageCategories`:
@@ -121,7 +121,7 @@ change.
     boolean props reactively (e.g. check `useControlModal.ts` / `AddSubcategoryModal.vue`
     usage) before finalizing.
 
-- [ ] **Step 4: Add Escape-key-to-close handling**
+- [x] **Step 4: Add Escape-key-to-close handling**
   - Add a `keydown` listener scoped appropriately. Two viable approaches — pick the one
     that matches how other components in this codebase scope keyboard listeners:
     - **Document-level** (robust regardless of focus): in `onMounted`, add
@@ -139,7 +139,7 @@ change.
     own Escape handling locally too, so this matches existing precedent of not
     over-abstracting a single keydown check).
 
-- [ ] **Step 5: Guard against interaction with teleported/portal content**
+- [x] **Step 5: Guard against interaction with teleported/portal content**
   - `CategoryView.vue` teleports its category options dropdown `to="body"` (see
     `useDropdownPosition.ts` usage) — teleported elements are **not** DOM descendants of
     `#manage-categories` even though they're logically "part of" the panel. Verify: does
@@ -160,7 +160,7 @@ change.
     only handle it if Step 5's investigation confirms it's a real problem, don't
     preemptively build a generic "ignore all portals" mechanism.
 
-- [ ] **Step 6: Verify no z-index or event-propagation regressions**
+- [x] **Step 6: Verify no z-index or event-propagation regressions**
   - Confirm the panel's `z-2000` remains above other page content so users can still
     see and interact with the panel itself (unaffected by this change, but re-check
     after adding the ref/listeners in case any wrapping accidentally changed the DOM
@@ -180,7 +180,7 @@ change.
     reproduces — check `NavigationBar.vue`'s toggle button markup/handler as part of
     this step to confirm the exact event binding before deciding on a fix.
 
-- [ ] **Step 7: Unit tests for `useClickOutside`**
+- [x] **Step 7: Unit tests for `useClickOutside`**
   - New file: `packages/frontend/src/helpers/hooks/__tests__/useClickOutside.test.ts`.
   - Follow the harness-component pattern from `useDropdownPosition.test.ts` (wrap the
     composable in a small `defineComponent` that renders a container element and exposes
@@ -194,7 +194,7 @@ change.
     - Listener is removed on unmount (no callback fires, no error, after the harness
       component is unmounted and a click is fired).
 
-- [ ] **Step 8: Unit tests for `ManageCategories.vue`**
+- [x] **Step 8: Unit tests for `ManageCategories.vue`**
   - New file: `packages/frontend/src/components/ManageCategories/__tests__/ManageCategories.test.ts`.
   - Use `@testing-library/vue`'s `render`/`screen`/`fireEvent`/`userEvent`, following
     `describe('when ...')` / `it('should ...')` phrasing (see `DropdownWithInput.test.ts`).
@@ -224,7 +224,7 @@ change.
       note in the test file if it needs to live in a `NavigationBar`/`App`-level test
       instead, since fixing it may require changes outside `ManageCategories.vue`).
 
-- [ ] **Step 9: Run the full unit test suite for the affected area**
+- [x] **Step 9: Run the full unit test suite for the affected area**
   - Run `packages/frontend`'s test command (e.g. `npm run test:unit` /
     `vitest run` scoped to the changed files) and confirm all new and existing tests
     pass, with particular attention to any existing `ManageCategories`-adjacent tests

--- a/.claude/plans/SPE-114.md
+++ b/.claude/plans/SPE-114.md
@@ -1,0 +1,245 @@
+# SPE-114: Clicking outside of Manage Categories side panel should close the panel
+
+## Problem
+
+`ManageCategories.vue` (`packages/frontend/src/components/ManageCategories/ManageCategories.vue`)
+renders the "Your Expense Categories" side panel as a bare `position: fixed` div
+(`#manage-categories`, `z-2000`) with **no backdrop**. The panel is controlled via a
+prop-down/event-up pattern: `isOpen: boolean` prop, `closeManageCategories` emit. It's
+toggled from `App.vue` (`isManageCategoriesOpen` ref) and opened via `NavigationBar.vue`.
+The only way to close it today is clicking the "X" button in the header
+(`emit('closeManageCategories')`). Clicking anywhere else on the page — including the
+still-visible, still-interactive content behind the panel — does nothing, which is
+surprising since the rest of the page remains clickable and visible (no backdrop dims
+or blocks it).
+
+There is **no existing click-outside infrastructure** anywhere in this codebase (no
+`@vueuse/core`, no custom directive, no composable) — confirmed via repo-wide grep.
+This will be new. There's also no existing backdrop/overlay pattern for this panel to
+piggy-back on (`Modal.vue`'s backdrop has no click handler either). The closest existing
+precedent is the blur+`sleep(100)` hack in
+`ManageCategories/hooks/useControlCategoryOptions.ts` for closing an options dropdown,
+which is a workaround for the *absence* of real click-outside detection, not something
+to reuse directly.
+
+## Approach
+
+Add a small reusable composable, `useClickOutside`, following this codebase's existing
+composable style (see `helpers/hooks/useDropdownPosition.ts`: takes refs, adds a
+`document`/`window` listener in `onMounted`, cleans up in `onUnmounted`). It attaches a
+single `document` `mousedown` (or `click`) listener, checks whether the event target is
+outside a given container ref, and invokes a callback if so. Reuse it from
+`ManageCategories.vue`, gated on `isOpen`, calling `emit('closeManageCategories')`.
+
+Also add an `Escape` keydown handler directly in `ManageCategories.vue`, following the
+existing pattern in `DropdownWithInput.vue` (`@keydown` checking
+`event.key === 'Escape'`), since the ticket's "close panel" intent reasonably extends to
+the keyboard and no such handling exists on this component today.
+
+Key implementation constraint: the panel uses `v-show`, not `v-if`, so
+`#manage-categories` is **always present in the DOM**, even when closed. The
+click-outside listener logic must gate on the `isOpen` prop itself (not on
+mount/unmount of the panel element) or every click anywhere in the app would evaluate
+the outside-check even while the panel is closed. Prefer checking `isOpen` inside the
+handler (cheap, avoids add/remove listener churn on every open/close) — but also
+acceptable to add/remove the listener reactively via a `watch` on `isOpen`; pick
+whichever keeps the composable simplest (see Step 1 for the recommended default).
+
+Do **not** add a backdrop div. The ticket only asks for click-outside-to-close, and
+introducing a backdrop would be a bigger visual/behavioral change (dimming the rest of
+the page) beyond what's requested — flag this as a possible follow-up, not part of this
+change.
+
+## Files to change
+
+| File | Change |
+|---|---|
+| New: `packages/frontend/src/helpers/hooks/useClickOutside.ts` | New composable: detects clicks outside a container ref and invokes a callback |
+| New: `packages/frontend/src/helpers/hooks/__tests__/useClickOutside.test.ts` | Unit tests for the composable (harness-component pattern, matching `useDropdownPosition.test.ts`) |
+| `packages/frontend/src/components/ManageCategories/ManageCategories.vue` | Wire up `useClickOutside` on the panel root; add `Escape` keydown handling |
+| New: `packages/frontend/src/components/ManageCategories/__tests__/ManageCategories.test.ts` | Unit tests covering click-outside, click-inside (no close), close button, and Escape key |
+
+## Steps
+
+- [ ] **Step 1: Create the `useClickOutside` composable**
+  - Location: `packages/frontend/src/helpers/hooks/useClickOutside.ts`, matching the
+    existing `helpers/hooks/` composable folder (alongside `useDropdownPosition.ts`).
+  - Signature (Composition API, matching `useDropdownPosition.ts`'s style of accepting
+    refs + reactive args):
+    ```ts
+    import { onMounted, onUnmounted, type Ref } from 'vue'
+
+    export function useClickOutside(
+      containerRef: Ref<HTMLElement | null | undefined>,
+      isActive: Ref<boolean> | (() => boolean),
+      onClickOutside: () => void,
+    ) {
+      function handleClick(event: MouseEvent) {
+        const active = typeof isActive === 'function' ? isActive() : isActive.value
+        if (!active) return
+        const container = containerRef.value
+        if (!container) return
+        if (container.contains(event.target as Node)) return
+        onClickOutside()
+      }
+
+      onMounted(() => document.addEventListener('mousedown', handleClick))
+      onUnmounted(() => document.removeEventListener('mousedown', handleClick))
+    }
+    ```
+  - Use `mousedown` rather than `click` — this avoids the panel re-opening/misfiring if
+    a `mouseup` lands somewhere unexpected after a drag, and is the conventional choice
+    for click-outside detection (matches "closes as soon as you start interacting
+    elsewhere" behavior users expect from panels/drawers).
+  - Gate on `isActive` inside the single always-registered listener (simpler than
+    watching `isOpen` to add/remove listeners, and cheap since it's just one global
+    listener regardless of how many times the panel opens/closes).
+  - Since `ManageCategories.vue` is a `<script setup>` component, the composable will be
+    called with `toRef(props, 'isOpen')` or an inline arrow function — decide in Step 3
+    based on what reads cleanest.
+
+- [ ] **Step 2: Add a template ref to `ManageCategories.vue`'s root panel div**
+  - Add `ref="panelRef"` to the `#manage-categories` div
+    (`ManageCategories.vue`, the `v-show="isOpen"` div).
+  - Declare `const panelRef = ref<HTMLElement | null>(null)` in the `<script setup>`
+    block.
+
+- [ ] **Step 3: Wire `useClickOutside` into `ManageCategories.vue`**
+  - Import `useClickOutside` from `@/helpers/hooks/useClickOutside`.
+  - Call it with the panel ref, an active-check based on `isOpen`, and a callback that
+    emits `closeManageCategories`:
+    ```ts
+    useClickOutside(panelRef, () => isOpen, () => emit('closeManageCategories'))
+    ```
+  - Since `isOpen` is a destructured prop (`const { isOpen } = defineProps<...>()`),
+    confirm whether destructuring preserves reactivity here — Vue 3.5's reactive props
+    destructure (compiler macro) does keep `isOpen` reactive inside `<script setup>`, so
+    the `() => isOpen` closure will see live updates. If this project's Vue/TS/compiler
+    config does *not* have reactive props destructure enabled, switch to
+    `defineProps` returning a `props` object and use `() => props.isOpen` instead —
+    verify against how other components in the codebase already consume `isOpen`-like
+    boolean props reactively (e.g. check `useControlModal.ts` / `AddSubcategoryModal.vue`
+    usage) before finalizing.
+
+- [ ] **Step 4: Add Escape-key-to-close handling**
+  - Add a `keydown` listener scoped appropriately. Two viable approaches — pick the one
+    that matches how other components in this codebase scope keyboard listeners:
+    - **Document-level** (robust regardless of focus): in `onMounted`, add
+      `document.addEventListener('keydown', handleKeydown)` where `handleKeydown` checks
+      `isOpen` and `event.key === 'Escape'`, then emits `closeManageCategories`; clean up
+      in `onUnmounted`. This matches the always-mounted (`v-show`) nature of the panel.
+    - **Template-level** `@keydown.esc` on the panel div, matching
+      `DropdownWithInput.vue`'s `@keydown` pattern — simpler, but only fires if focus is
+      currently inside the panel, which may not cover all cases (e.g. focus is on the
+      toggle button in `NavigationBar.vue` when Escape is pressed).
+  - Recommend the document-level approach for parity with `useClickOutside` (same
+    lifecycle shape, same "works regardless of where focus is" guarantee) — implement
+    inline in `ManageCategories.vue` (not a separate composable; this ticket doesn't
+    call for reuse elsewhere, and `DropdownWithInput.vue`/`TableCell.vue` each roll their
+    own Escape handling locally too, so this matches existing precedent of not
+    over-abstracting a single keydown check).
+
+- [ ] **Step 5: Guard against interaction with teleported/portal content**
+  - `CategoryView.vue` teleports its category options dropdown `to="body"` (see
+    `useDropdownPosition.ts` usage) — teleported elements are **not** DOM descendants of
+    `#manage-categories` even though they're logically "part of" the panel. Verify: does
+    opening that teleported dropdown (three-dot options menu) and clicking one of its
+    options trigger `useClickOutside`'s `mousedown` handler and incorrectly close the
+    whole panel, since `container.contains(event.target)` would return `false` for a
+    teleported node?
+  - Also check `AddSubcategoryModal.vue` / `UpdateNameModal.vue` (opened via
+    `useControlModal.ts` from within `CategoryView.vue`) — confirm whether `Modal.vue`
+    teleports its content or renders inline. If it teleports, a click inside that modal
+    while the Manage Categories panel is open would likewise be misidentified as
+    "outside" and incorrectly close the panel underneath it (modal-stacking edge case).
+  - If either is teleported outside `#manage-categories`, extend the outside-check to
+    also treat clicks inside known teleported/child overlay elements as "inside" — e.g.
+    check `event.target` against a data attribute (`[data-manage-categories-child]`) set
+    on relevant teleported roots, or simply check whether the click landed inside *any*
+    currently-open modal/dropdown before treating it as outside. Keep this minimal:
+    only handle it if Step 5's investigation confirms it's a real problem, don't
+    preemptively build a generic "ignore all portals" mechanism.
+
+- [ ] **Step 6: Verify no z-index or event-propagation regressions**
+  - Confirm the panel's `z-2000` remains above other page content so users can still
+    see and interact with the panel itself (unaffected by this change, but re-check
+    after adding the ref/listeners in case any wrapping accidentally changed the DOM
+    structure — it shouldn't, since `useClickOutside` doesn't wrap or add DOM).
+  - Confirm the "X" close button's own click still works and doesn't double-fire
+    `closeManageCategories` (clicking the button is *inside* `#manage-categories`, so
+    `useClickOutside` won't fire for it — only the button's own `@click` handler will).
+  - Confirm clicking the "Manage Categories" toggle button in `NavigationBar.vue` while
+    the panel is open doesn't both (a) close it via `useClickOutside` (since that button
+    is outside `#manage-categories`) and (b) re-toggle it open via
+    `toggleManageCategories()`, resulting in it staying open when the user expects a
+    toggle-close, or flickering. Since `mousedown` fires before `click`, and
+    `toggleManageCategories` is presumably bound to `click`, the sequence would be:
+    `mousedown` → `useClickOutside` closes panel → `click` → `toggleManageCategories`
+    flips it back open. This is a real edge case to test explicitly (Step 8) and may
+    need `event.stopPropagation()`/a shared "ignore this element" mechanism if it
+    reproduces — check `NavigationBar.vue`'s toggle button markup/handler as part of
+    this step to confirm the exact event binding before deciding on a fix.
+
+- [ ] **Step 7: Unit tests for `useClickOutside`**
+  - New file: `packages/frontend/src/helpers/hooks/__tests__/useClickOutside.test.ts`.
+  - Follow the harness-component pattern from `useDropdownPosition.test.ts` (wrap the
+    composable in a small `defineComponent` that renders a container element and exposes
+    a way to toggle `isActive` / observe the callback), tested via
+    `@testing-library/vue`'s `render`/`screen`/`fireEvent`.
+  - Cases:
+    - Clicking outside the container while active calls the callback.
+    - Clicking inside the container while active does *not* call the callback.
+    - Clicking outside while inactive (`isActive` false / panel closed) does not call
+      the callback.
+    - Listener is removed on unmount (no callback fires, no error, after the harness
+      component is unmounted and a click is fired).
+
+- [ ] **Step 8: Unit tests for `ManageCategories.vue`**
+  - New file: `packages/frontend/src/components/ManageCategories/__tests__/ManageCategories.test.ts`.
+  - Use `@testing-library/vue`'s `render`/`screen`/`fireEvent`/`userEvent`, following
+    `describe('when ...')` / `it('should ...')` phrasing (see `DropdownWithInput.test.ts`).
+  - Mock `getStore` (the component calls `getStore()` directly) — check how
+    `AddDataView.test.ts` mocks `getStore` for the pattern.
+  - Cases:
+    - `describe('when the panel is open')`:
+      - `it('should call closeManageCategories when clicking outside the panel')` —
+        render with `isOpen: true`, `fireEvent.mouseDown(document.body)` (or a sibling
+        element outside `#manage-categories`), assert `emitted().closeManageCategories`
+        has one entry.
+      - `it('should not emit closeManageCategories when clicking inside the panel')` —
+        click an element inside the panel (e.g. the header `<h2>`), assert no emit.
+      - `it('should emit closeManageCategories when clicking the close button')` —
+        existing behavior, regression-guard.
+      - `it('should emit closeManageCategories when pressing Escape')` — 
+        `fireEvent.keyDown(document, { key: 'Escape' })`, assert emit (Step 4).
+    - `describe('when the panel is closed')`:
+      - `it('should not emit closeManageCategories when clicking outside')` — render
+        with `isOpen: false`, click outside, assert no emit (guards the `isActive` gate
+        added in Step 1/3).
+    - If Step 5's investigation found a real teleported-content issue, add a regression
+      test here reproducing it (open the category options dropdown or a sub-modal,
+      click inside it, assert the panel does *not* close).
+    - If Step 6's investigation found the toggle-button double-fire issue, add a
+      regression test reproducing the NavigationBar toggle interaction end-to-end (or
+      note in the test file if it needs to live in a `NavigationBar`/`App`-level test
+      instead, since fixing it may require changes outside `ManageCategories.vue`).
+
+- [ ] **Step 9: Run the full unit test suite for the affected area**
+  - Run `packages/frontend`'s test command (e.g. `npm run test:unit` /
+    `vitest run` scoped to the changed files) and confirm all new and existing tests
+    pass, with particular attention to any existing `ManageCategories`-adjacent tests
+    (e.g. `CategoryView`, `App.vue` tests if any) that might be affected by the new
+    global `mousedown`/`keydown` listeners.
+
+## Edge cases
+
+| Scenario | Expected behaviour |
+|---|---|
+| Click on a child element inside the panel (header text, category list item, "Add Category" input) | Panel stays open — `useClickOutside`'s `container.contains(event.target)` check returns true for any descendant |
+| Click the "X" close button | Panel closes via its own existing `@click` handler; `useClickOutside` does not also fire (button is inside the container) — no double-emit |
+| Click the "Manage Categories" toggle button in `NavigationBar.vue` while panel is open | Needs explicit verification (Step 6/8) — risk of close-then-reopen flicker due to `mousedown` (outside-click) firing before `click` (toggle handler) |
+| Click inside a teleported child (category options dropdown, `AddSubcategoryModal`/`UpdateNameModal` if teleported) | Must NOT incorrectly close the panel — verify in Step 5, since teleported nodes are not DOM descendants of `#manage-categories` even though they're logically nested |
+| Panel is closed (`isOpen: false`) and user clicks anywhere on the page | No-op — `isActive`/`isOpen` gate in `useClickOutside` prevents the callback from firing on a hidden (`v-show`) panel |
+| Escape pressed while panel is open | Panel closes (Step 4) |
+| Escape pressed while panel is closed, or while focus is inside an unrelated input elsewhere on the page | No-op — gated on `isOpen`, and Escape doesn't interfere with unrelated components since it only calls `closeManageCategories`, not `preventDefault`/`stopPropagation` broadly (avoid swallowing Escape for other listeners like `DropdownWithInput`'s own Escape handling, unless testing shows a conflict) |
+| Rapid open → click outside within the same animation frame (panel is still transitioning via the `<Transition>` `translate-x-full`/`translate-x-0` classes) | Not expected to cause issues since `v-show` keeps the element present and `isOpen` flips synchronously with the prop; not a blocking concern but worth a quick manual sanity check if time allows |

--- a/packages/frontend/src/components/ManageCategories/CategoryView.vue
+++ b/packages/frontend/src/components/ManageCategories/CategoryView.vue
@@ -96,6 +96,7 @@ const error = deleteCategoryError || deleteSubCategoryError || updateCategoryErr
           <div
             v-if="isOptionsOpen"
             ref="optionsDivRef"
+            data-manage-categories-portal
             class="category-options fixed z-10000 bg-gray-50 flex flex-col gap-1 w-38 shadow-xs border"
             :style="{ top: optionsTop + 'px', left: optionsLeft + 'px' }"
           >

--- a/packages/frontend/src/components/ManageCategories/ManageCategories.vue
+++ b/packages/frontend/src/components/ManageCategories/ManageCategories.vue
@@ -1,8 +1,10 @@
 <script lang="ts" setup>
+import { onMounted, onUnmounted, ref } from 'vue'
 import CategoryView from './CategoryView.vue'
 import AddCategory from './AddCategory.vue'
 import Button from '@/components/DesignSystem/Button/Button.vue'
 import { getStore } from '@/store/store'
+import { useClickOutside } from '@/helpers/hooks/useClickOutside'
 
 const store = getStore()
 
@@ -13,6 +15,24 @@ const { isOpen } = defineProps<{
 const emit = defineEmits<{
   closeManageCategories: []
 }>()
+
+const panelRef = ref<HTMLElement | null>(null)
+
+useClickOutside(
+  panelRef,
+  () => isOpen,
+  () => emit('closeManageCategories'),
+  { ignoreSelector: '[data-manage-categories-portal]' },
+)
+
+function handleKeydown(event: KeyboardEvent) {
+  if (!isOpen) return
+  if (event.key !== 'Escape') return
+  emit('closeManageCategories')
+}
+
+onMounted(() => document.addEventListener('keydown', handleKeydown))
+onUnmounted(() => document.removeEventListener('keydown', handleKeydown))
 </script>
 
 <template>
@@ -27,6 +47,7 @@ const emit = defineEmits<{
     <div
       v-show="isOpen"
       id="manage-categories"
+      ref="panelRef"
       class="flex flex-col fixed border bg-gray-50 z-2000 p-5 top-15 right-0 h-[calc(100vh-61px)] box-border min-w-[30vw] max-w-[50vw] shadow-xl"
     >
       <div id="manage-categories-header" class="flex justify-between items-center mb-4">

--- a/packages/frontend/src/components/ManageCategories/__tests__/ManageCategories.test.ts
+++ b/packages/frontend/src/components/ManageCategories/__tests__/ManageCategories.test.ts
@@ -1,0 +1,121 @@
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { defineComponent, ref } from 'vue'
+import { describe, expect, it, vi } from 'vitest'
+import type { Store } from '@/store/storeInterface'
+import ManageCategories from '../ManageCategories.vue'
+
+vi.mock('@/store/store', () => ({
+  getStore: () =>
+    ({
+      categories: ref([]),
+    }) as unknown as Store,
+}))
+
+vi.mock('../CategoryView.vue', () => ({
+  default: {
+    name: 'MockCategoryView',
+    props: ['category'],
+    template: '<div data-testid="mock-category-view" />',
+  },
+}))
+
+vi.mock('../AddCategory.vue', () => ({
+  default: {
+    name: 'MockAddCategory',
+    template: '<div data-testid="mock-add-category" />',
+  },
+}))
+
+describe('when the manage categories panel is open', () => {
+  it('should emit closeManageCategories when clicking outside the panel', async () => {
+    const { emitted } = render(ManageCategories, { props: { isOpen: true } })
+
+    document.body.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+    expect(emitted().closeManageCategories).toHaveLength(1)
+  })
+
+  it('should not emit closeManageCategories when clicking inside the panel', async () => {
+    const { emitted } = render(ManageCategories, { props: { isOpen: true } })
+
+    await userEvent.click(screen.getByText('Your Expense Categories'))
+
+    expect(emitted().closeManageCategories).toBeUndefined()
+  })
+
+  it('should emit closeManageCategories when clicking the close button', async () => {
+    const { emitted } = render(ManageCategories, { props: { isOpen: true } })
+
+    await userEvent.click(screen.getByText('X'))
+
+    expect(emitted().closeManageCategories).toHaveLength(1)
+  })
+
+  it('should emit closeManageCategories when pressing Escape', async () => {
+    const { emitted } = render(ManageCategories, { props: { isOpen: true } })
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+
+    expect(emitted().closeManageCategories).toHaveLength(1)
+  })
+})
+
+describe('when clicking the external toggle button that opened the panel', () => {
+  it('should stay closed instead of flickering back open', async () => {
+    const ToggleHarness = defineComponent({
+      components: { ManageCategories },
+      setup() {
+        const isOpen = ref(true)
+        function toggle() {
+          isOpen.value = !isOpen.value
+        }
+        return { isOpen, toggle }
+      },
+      template: `<div>
+        <button data-testid="toggle-button" @click="toggle">Manage Categories</button>
+        <ManageCategories :is-open="isOpen" @close-manage-categories="isOpen = false" />
+      </div>`,
+    })
+
+    render(ToggleHarness)
+
+    await userEvent.click(screen.getByTestId('toggle-button'))
+
+    expect(screen.getByText('Your Expense Categories').closest('#manage-categories')).not.toBeVisible()
+  })
+})
+
+describe('when clicking inside a teleported child of the panel', () => {
+  it('should not close the panel', async () => {
+    const { emitted } = render(ManageCategories, { props: { isOpen: true } })
+
+    const portalElement = document.createElement('button')
+    portalElement.setAttribute('data-manage-categories-portal', '')
+    document.body.appendChild(portalElement)
+
+    portalElement.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+    expect(emitted().closeManageCategories).toBeUndefined()
+
+    document.body.removeChild(portalElement)
+  })
+})
+
+describe('when the manage categories panel is closed', () => {
+  it('should not emit closeManageCategories when clicking outside', async () => {
+    const { emitted } = render(ManageCategories, { props: { isOpen: false } })
+
+    document.body.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+    expect(emitted().closeManageCategories).toBeUndefined()
+  })
+
+  it('should not emit closeManageCategories when pressing Escape', async () => {
+    const { emitted } = render(ManageCategories, { props: { isOpen: false } })
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+
+    expect(emitted().closeManageCategories).toBeUndefined()
+  })
+})

--- a/packages/frontend/src/helpers/hooks/__tests__/useClickOutside.test.ts
+++ b/packages/frontend/src/helpers/hooks/__tests__/useClickOutside.test.ts
@@ -1,0 +1,85 @@
+import { render, screen } from '@testing-library/vue'
+import { defineComponent, ref } from 'vue'
+import { describe, expect, it, vi } from 'vitest'
+import { useClickOutside, type UseClickOutsideOptions } from '../useClickOutside'
+
+function createClickOutsideHarness(
+  onClickOutside: () => void,
+  initialIsActive: boolean,
+  options?: UseClickOutsideOptions,
+) {
+  return defineComponent({
+    setup() {
+      const containerRef = ref<HTMLElement | null>(null)
+      const isActive = ref(initialIsActive)
+
+      useClickOutside(containerRef, () => isActive.value, onClickOutside, options)
+
+      return { containerRef, isActive }
+    },
+    template: `<div>
+      <div ref="containerRef" data-testid="container">
+        <button data-testid="inside-button">inside</button>
+      </div>
+      <button data-testid="outside-button">outside</button>
+      <div data-testid="ignored-portal" data-portal-marker>
+        <button data-testid="ignored-portal-button">portal option</button>
+      </div>
+    </div>`,
+  })
+}
+
+describe('when useClickOutside is used on a container', () => {
+  it('should call the callback when clicking outside the container while active', async () => {
+    const onClickOutside = vi.fn()
+    render(createClickOutsideHarness(onClickOutside, true))
+
+    screen.getByTestId('outside-button').dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+    expect(onClickOutside).toHaveBeenCalledTimes(1)
+  })
+
+  it('should not call the callback when clicking inside the container while active', async () => {
+    const onClickOutside = vi.fn()
+    render(createClickOutsideHarness(onClickOutside, true))
+
+    screen.getByTestId('inside-button').dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+    expect(onClickOutside).not.toHaveBeenCalled()
+  })
+
+  it('should not call the callback when clicking outside while inactive', async () => {
+    const onClickOutside = vi.fn()
+    render(createClickOutsideHarness(onClickOutside, false))
+
+    screen.getByTestId('outside-button').dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+    expect(onClickOutside).not.toHaveBeenCalled()
+  })
+
+  it('should not call the callback after the component is unmounted', async () => {
+    const onClickOutside = vi.fn()
+    const { unmount } = render(createClickOutsideHarness(onClickOutside, true))
+    const outsideButton = screen.getByTestId('outside-button')
+
+    unmount()
+    outsideButton.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+    expect(onClickOutside).not.toHaveBeenCalled()
+  })
+
+  it('should not call the callback when clicking inside an element matching ignoreSelector, even though it is outside the container', async () => {
+    const onClickOutside = vi.fn()
+    render(
+      createClickOutsideHarness(onClickOutside, true, {
+        ignoreSelector: '[data-portal-marker]',
+      }),
+    )
+
+    screen
+      .getByTestId('ignored-portal-button')
+      .dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+    expect(onClickOutside).not.toHaveBeenCalled()
+  })
+})

--- a/packages/frontend/src/helpers/hooks/useClickOutside.ts
+++ b/packages/frontend/src/helpers/hooks/useClickOutside.ts
@@ -1,0 +1,61 @@
+import { onMounted, onUnmounted, type Ref } from 'vue'
+
+export interface UseClickOutsideOptions {
+  /**
+   * Clicks landing inside an element matching this selector are treated as
+   * "inside" even if they aren't a DOM descendant of containerRef. Needed for
+   * content that is teleported elsewhere in the DOM (e.g. `<Teleport to="body">`)
+   * but is logically part of the container.
+   */
+  ignoreSelector?: string
+}
+
+/**
+ * Invokes `onClickOutside` when a `click` lands outside `containerRef`, while
+ * `isActive()` returns true. A single `document`-level listener is registered
+ * on mount and removed on unmount; it stays registered for the component's
+ * whole lifetime and is gated by `isActive()` on every click rather than
+ * being added/removed as the container opens and closes, so this is safe to
+ * use on elements that stay mounted (e.g. `v-show` panels) as well as ones
+ * that are conditionally rendered (`v-if`).
+ *
+ * Listens on `click` rather than `mousedown` deliberately: if the same click
+ * both opens/closes the container via another handler (e.g. a toggle button
+ * outside the container) and would also be seen by this listener, using
+ * `click` guarantees the toggle handler on the closer target runs first
+ * during the bubble phase, so `isActive()` already reflects the new state by
+ * the time this listener runs — avoiding a close-then-reopen flicker that
+ * `mousedown` (a separate, earlier event) would cause.
+ *
+ * Pass `ignoreSelector` when the container has logical children that live
+ * elsewhere in the DOM via `<Teleport>` — e.g. a dropdown or modal rendered
+ * to `<body>`. Such elements aren't real DOM descendants of `containerRef`,
+ * so `containerRef.value.contains(event.target)` returns false for them even
+ * though a click on them shouldn't count as "outside." Mark the teleported
+ * root with an attribute (e.g. `data-my-thing-portal`) and pass a matching
+ * selector (e.g. `'[data-my-thing-portal]'`) to have clicks inside it ignored.
+ *
+ * @param containerRef - Ref to the element clicks are checked against; a click is "outside" if it (or its DOM ancestor chain) isn't this element or one of its descendants.
+ * @param isActive - Called on every click; the click is ignored entirely when this returns false (e.g. pass `() => isOpen` so closed/unmounted-in-spirit containers don't react to clicks).
+ * @param onClickOutside - Called once per outside click, e.g. `() => emit('close')`.
+ * @param options.ignoreSelector - CSS selector; clicks landing inside a matching element are treated as "inside" even though they aren't DOM descendants of `containerRef` (for `<Teleport>`-rendered content).
+ */
+export function useClickOutside(
+  containerRef: Ref<HTMLElement | null | undefined>,
+  isActive: () => boolean,
+  onClickOutside: () => void,
+  options?: UseClickOutsideOptions,
+) {
+  function handleClick(event: MouseEvent) {
+    if (!isActive()) return
+    const container = containerRef.value
+    if (!container) return
+    const target = event.target as Node
+    if (container.contains(target)) return
+    if (options?.ignoreSelector && (target as HTMLElement).closest?.(options.ignoreSelector)) return
+    onClickOutside()
+  }
+
+  onMounted(() => document.addEventListener('click', handleClick))
+  onUnmounted(() => document.removeEventListener('click', handleClick))
+}


### PR DESCRIPTION
## Summary
- Clicking anywhere outside the Manage Categories side panel now closes it, in addition to the existing close ("X") button.
- Pressing Escape while the panel is open also closes it.
- Adds a reusable `useClickOutside` composable (`packages/frontend/src/helpers/hooks/useClickOutside.ts`).

## Notable fixes found during implementation
- Listens on `click` rather than `mousedown` to avoid a close-then-reopen flicker when the "Manage Categories" toggle button (outside the panel) is clicked while the panel is open.
- Supports an `ignoreSelector` option so clicks inside the teleported category options dropdown (`<Teleport to="body">` in `CategoryView.vue`) aren't misidentified as "outside" clicks and don't incorrectly close the panel.

## Test plan
- [x] New unit tests for `useClickOutside` (outside click, inside click, inactive state, unmount cleanup, ignoreSelector)
- [x] New unit tests for `ManageCategories.vue` (outside click, inside click, close button, Escape key, closed-state no-ops, toggle-button regression, teleported-portal regression)
- [x] Full frontend test suite passing (`vitest run`)
- [x] `vue-tsc --noEmit` clean
- [x] `eslint` clean

Linear: https://linear.app/spendtrend/issue/SPE-114/clicking-outside-of-manage-categories-side-panel-should-close-the

🤖 Generated with [Claude Code](https://claude.com/claude-code)