### PR TITLE
Fix follow-up bugs in click-outside-closes-manage-categories (SPE-114)

### DIFF
--- a/packages/frontend/src/components/ManageCategories/CategoryView.vue
+++ b/packages/frontend/src/components/ManageCategories/CategoryView.vue
@@ -40,8 +40,10 @@ const { isModalOpen: isUpdateCategoryModalOpen, openModal: openUpdateCategoryMod
 
 const {
   isOptionsOpen,
+  isOptionsClosing,
   toggleOptions: originalToggleOptions,
   closeOptions,
+  hideOptionsImmediately,
 } = useControlCategoryOptions()
 
 const optionsRef = ref<HTMLElement>()
@@ -52,6 +54,11 @@ const { optionsTop, optionsLeft, positionDropdown } = useDropdownPosition(option
 async function toggleOptions() {
   originalToggleOptions()
   await positionDropdown(isOptionsOpen.value)
+}
+
+function handleOptionSelected(action: () => void) {
+  hideOptionsImmediately()
+  action()
 }
 
 const showSubCategories = ref(false)
@@ -98,6 +105,7 @@ const error = deleteCategoryError || deleteSubCategoryError || updateCategoryErr
             ref="optionsDivRef"
             data-manage-categories-portal
             class="category-options fixed z-10000 bg-gray-50 flex flex-col gap-1 w-38 shadow-xs border"
+            :class="{ invisible: isOptionsClosing }"
             :style="{ top: optionsTop + 'px', left: optionsLeft + 'px' }"
           >
             <span
@@ -105,7 +113,7 @@ const error = deleteCategoryError || deleteSubCategoryError || updateCategoryErr
               :key="option.name"
               class="hover:bg-gray-200 px-3.5 py-1.5 rounded-md"
             >
-              <Button :key="option.name" type="text" @mousedown="option.action">
+              <Button :key="option.name" type="text" @mousedown="handleOptionSelected(option.action)">
                 {{ option.name }}
               </Button>
             </span>

--- a/packages/frontend/src/components/ManageCategories/CategoryView.vue
+++ b/packages/frontend/src/components/ManageCategories/CategoryView.vue
@@ -105,7 +105,7 @@ const error = deleteCategoryError || deleteSubCategoryError || updateCategoryErr
             ref="optionsDivRef"
             data-manage-categories-portal
             class="category-options fixed z-10000 bg-gray-50 flex flex-col gap-1 w-38 shadow-xs border"
-            :class="{ invisible: isOptionsClosing }"
+            :class="{ 'opacity-0': isOptionsClosing }"
             :style="{ top: optionsTop + 'px', left: optionsLeft + 'px' }"
           >
             <span

--- a/packages/frontend/src/components/ManageCategories/ManageCategories.vue
+++ b/packages/frontend/src/components/ManageCategories/ManageCategories.vue
@@ -8,7 +8,7 @@ import { useClickOutside } from '@/helpers/hooks/useClickOutside'
 
 const store = getStore()
 
-const { isOpen } = defineProps<{
+const props = defineProps<{
   isOpen: boolean
 }>()
 
@@ -20,13 +20,13 @@ const panelRef = ref<HTMLElement | null>(null)
 
 useClickOutside(
   panelRef,
-  () => isOpen,
+  () => props.isOpen,
   () => emit('closeManageCategories'),
-  { ignoreSelector: '[data-manage-categories-portal]' },
+  { ignoreSelector: '[data-manage-categories-portal], [data-manage-categories-toggle]' },
 )
 
 function handleKeydown(event: KeyboardEvent) {
-  if (!isOpen) return
+  if (!props.isOpen) return
   if (event.key !== 'Escape') return
   emit('closeManageCategories')
 }

--- a/packages/frontend/src/components/ManageCategories/SubcategoryView.vue
+++ b/packages/frontend/src/components/ManageCategories/SubcategoryView.vue
@@ -88,6 +88,7 @@ const subCategoryOptions = (subCategory: ExpenseSubCategory) => [
     <div
       v-if="activeOptionsSubCategoryId"
       ref="optionsDivRef"
+      data-manage-categories-portal
       class="subcategory-options fixed z-10000 bg-gray-50 flex flex-col gap-1 w-38 shadow-xs border"
       :style="{ top: optionsTop + 'px', left: optionsLeft + 'px' }"
     >

--- a/packages/frontend/src/components/ManageCategories/__tests__/ManageCategories.test.ts
+++ b/packages/frontend/src/components/ManageCategories/__tests__/ManageCategories.test.ts
@@ -61,24 +61,33 @@ describe('when the manage categories panel is open', () => {
   })
 })
 
-describe('when clicking the external toggle button that opened the panel', () => {
-  it('should stay closed instead of flickering back open', async () => {
-    const ToggleHarness = defineComponent({
-      components: { ManageCategories },
-      setup() {
-        const isOpen = ref(true)
-        function toggle() {
-          isOpen.value = !isOpen.value
-        }
-        return { isOpen, toggle }
-      },
-      template: `<div>
-        <button data-testid="toggle-button" @click="toggle">Manage Categories</button>
-        <ManageCategories :is-open="isOpen" @close-manage-categories="isOpen = false" />
-      </div>`,
-    })
+describe('when clicking the external toggle button that opens/closes the panel', () => {
+  const ToggleHarness = defineComponent({
+    components: { ManageCategories },
+    props: { initialIsOpen: { type: Boolean, default: false } },
+    setup(props) {
+      const isOpen = ref(props.initialIsOpen)
+      function toggle() {
+        isOpen.value = !isOpen.value
+      }
+      return { isOpen, toggle }
+    },
+    template: `<div>
+      <button data-testid="toggle-button" data-manage-categories-toggle @click="toggle">Manage Categories</button>
+      <ManageCategories :is-open="isOpen" @close-manage-categories="isOpen = false" />
+    </div>`,
+  })
 
-    render(ToggleHarness)
+  it('should open the panel and keep it open when clicking the toggle button while closed', async () => {
+    render(ToggleHarness, { props: { initialIsOpen: false } })
+
+    await userEvent.click(screen.getByTestId('toggle-button'))
+
+    expect(screen.getByText('Your Expense Categories').closest('#manage-categories')).toBeVisible()
+  })
+
+  it('should close the panel instead of flickering back open when clicking the toggle button while open', async () => {
+    render(ToggleHarness, { props: { initialIsOpen: true } })
 
     await userEvent.click(screen.getByTestId('toggle-button'))
 

--- a/packages/frontend/src/components/ManageCategories/__tests__/ManageCategoriesPortalIntegration.test.ts
+++ b/packages/frontend/src/components/ManageCategories/__tests__/ManageCategoriesPortalIntegration.test.ts
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { ref } from 'vue'
+import { describe, expect, it, vi } from 'vitest'
+import type { Store } from '@/store/storeInterface'
+import ManageCategories from '../ManageCategories.vue'
+
+vi.mock('@/store/store', () => ({
+  getStore: () =>
+    ({
+      categories: ref([{ name: 'Food', subCategories: [{ id: 'sc1', name: 'Snacks' }] }]),
+      updateSubCategory: vi.fn(),
+    }) as unknown as Store,
+}))
+
+vi.mock('@/service/categories/updateCategory', () => ({
+  updateCategory: vi.fn(() => new Promise(() => {})),
+}))
+vi.mock('@/service/categories/deleteCategory', () => ({
+  deleteCategory: vi.fn(() => new Promise(() => {})),
+}))
+vi.mock('@/service/categories/addNewCategories', () => ({
+  addNewCategory: vi.fn(() => new Promise(() => {})),
+}))
+vi.mock('@/service/categories/deleteSubCategory', () => ({
+  deleteSubCategory: vi.fn(() => new Promise(() => {})),
+}))
+vi.mock('@/service/categories/updateSubCategory', () => ({
+  updateSubCategory: vi.fn(() => new Promise(() => {})),
+}))
+
+/**
+ * This exercises the real CategoryView/SubcategoryView tree (unlike ManageCategories.test.ts,
+ * which stubs CategoryView) because the teleported subcategory options dropdown is a separate
+ * <Teleport to="body"> in SubcategoryView.vue that needs its own data-manage-categories-portal
+ * marker for useClickOutside to ignore clicks on it. Regression test for a bug where clicking a
+ * subcategory's "⋮" options and then an option closed the whole panel.
+ */
+describe('when interacting with the teleported subcategory options dropdown', () => {
+  it('should not close the panel when opening the subcategory options dropdown or clicking an option in it', async () => {
+    const { emitted } = render(ManageCategories, { props: { isOpen: true } })
+
+    await userEvent.click(screen.getByText('Food'))
+
+    const optionsButtons = screen.getAllByText('⋮')
+    const subCategoryOptionsButton = optionsButtons[optionsButtons.length - 1]
+    await userEvent.click(subCategoryOptionsButton)
+
+    expect(emitted().closeManageCategories).toBeUndefined()
+
+    await userEvent.click(screen.getByText('Update SubCategory'))
+
+    expect(emitted().closeManageCategories).toBeUndefined()
+  })
+})

--- a/packages/frontend/src/components/ManageCategories/hooks/__tests__/useControlCategoryOptions.test.ts
+++ b/packages/frontend/src/components/ManageCategories/hooks/__tests__/useControlCategoryOptions.test.ts
@@ -13,7 +13,7 @@ const ControlCategoryOptionsHarness = defineComponent({
   },
   template: `<div>
     <button data-testid="toggle" @click="toggleOptions" @blur="closeOptions">⋮</button>
-    <div v-if="isOptionsOpen" data-testid="options" :class="{ invisible: isOptionsClosing }">
+    <div v-if="isOptionsOpen" data-testid="options" :class="{ 'opacity-0': isOptionsClosing }">
       <button data-testid="option" @mousedown="hideOptionsImmediately">Update Category</button>
     </div>
   </div>`,
@@ -26,7 +26,7 @@ describe('when using the category options dropdown', () => {
     await userEvent.click(screen.getByTestId('toggle'))
 
     const options = screen.getByTestId('options')
-    expect(options).not.toHaveClass('invisible')
+    expect(options).not.toHaveClass('opacity-0')
   })
 
   it('should hide the dropdown immediately (before it is unmounted) when an option is selected', async () => {
@@ -37,7 +37,7 @@ describe('when using the category options dropdown', () => {
     await nextTick()
 
     const options = screen.getByTestId('options')
-    expect(options).toHaveClass('invisible')
+    expect(options).toHaveClass('opacity-0')
   })
 
   it('should reset the closing state when reopened', async () => {
@@ -46,12 +46,12 @@ describe('when using the category options dropdown', () => {
     await userEvent.click(screen.getByTestId('toggle'))
     screen.getByTestId('option').dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
     await nextTick()
-    expect(screen.getByTestId('options')).toHaveClass('invisible')
+    expect(screen.getByTestId('options')).toHaveClass('opacity-0')
 
     await userEvent.click(screen.getByTestId('toggle'))
     expect(screen.queryByTestId('options')).not.toBeInTheDocument()
 
     await userEvent.click(screen.getByTestId('toggle'))
-    expect(screen.getByTestId('options')).not.toHaveClass('invisible')
+    expect(screen.getByTestId('options')).not.toHaveClass('opacity-0')
   })
 })

--- a/packages/frontend/src/components/ManageCategories/hooks/__tests__/useControlCategoryOptions.test.ts
+++ b/packages/frontend/src/components/ManageCategories/hooks/__tests__/useControlCategoryOptions.test.ts
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { defineComponent, nextTick } from 'vue'
+import { describe, expect, it } from 'vitest'
+import { useControlCategoryOptions } from '../useControlCategoryOptions'
+
+const ControlCategoryOptionsHarness = defineComponent({
+  setup() {
+    const { isOptionsOpen, isOptionsClosing, toggleOptions, closeOptions, hideOptionsImmediately } =
+      useControlCategoryOptions()
+
+    return { isOptionsOpen, isOptionsClosing, toggleOptions, closeOptions, hideOptionsImmediately }
+  },
+  template: `<div>
+    <button data-testid="toggle" @click="toggleOptions" @blur="closeOptions">⋮</button>
+    <div v-if="isOptionsOpen" data-testid="options" :class="{ invisible: isOptionsClosing }">
+      <button data-testid="option" @mousedown="hideOptionsImmediately">Update Category</button>
+    </div>
+  </div>`,
+})
+
+describe('when using the category options dropdown', () => {
+  it('should open the dropdown, visible and not closing', async () => {
+    render(ControlCategoryOptionsHarness)
+
+    await userEvent.click(screen.getByTestId('toggle'))
+
+    const options = screen.getByTestId('options')
+    expect(options).not.toHaveClass('invisible')
+  })
+
+  it('should hide the dropdown immediately (before it is unmounted) when an option is selected', async () => {
+    render(ControlCategoryOptionsHarness)
+
+    await userEvent.click(screen.getByTestId('toggle'))
+    screen.getByTestId('option').dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+    await nextTick()
+
+    const options = screen.getByTestId('options')
+    expect(options).toHaveClass('invisible')
+  })
+
+  it('should reset the closing state when reopened', async () => {
+    render(ControlCategoryOptionsHarness)
+
+    await userEvent.click(screen.getByTestId('toggle'))
+    screen.getByTestId('option').dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+    await nextTick()
+    expect(screen.getByTestId('options')).toHaveClass('invisible')
+
+    await userEvent.click(screen.getByTestId('toggle'))
+    expect(screen.queryByTestId('options')).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByTestId('toggle'))
+    expect(screen.getByTestId('options')).not.toHaveClass('invisible')
+  })
+})

--- a/packages/frontend/src/components/ManageCategories/hooks/useControlCategoryOptions.ts
+++ b/packages/frontend/src/components/ManageCategories/hooks/useControlCategoryOptions.ts
@@ -16,6 +16,17 @@ export function useControlCategoryOptions(): {
     isOptionsClosing.value = false
   }
 
+  /**
+   * Set true by the consumer when an option is selected, to hide the dropdown before the
+   * 100ms delay in closeOptions() actually unmounts it (see closeOptions for why that delay
+   * exists). Bind this to an `opacity-0` class, NOT `invisible`/`visibility: hidden` or
+   * `hidden`/`display: none`: those remove the element from hit-testing, and since this flips
+   * synchronously inside the option's own `mousedown` handler, the browser can retarget the
+   * still-in-flight `mouseup`/`click` of that same gesture away from the (now unhittable)
+   * option button — observed landing on `document.body` — which useClickOutside then
+   * legitimately reads as a click outside the panel and closes it. `opacity-0` hides the
+   * pixels without touching hit-testing, so the in-flight click resolves normally.
+   */
   function hideOptionsImmediately() {
     isOptionsClosing.value = true
   }

--- a/packages/frontend/src/components/ManageCategories/hooks/useControlCategoryOptions.ts
+++ b/packages/frontend/src/components/ManageCategories/hooks/useControlCategoryOptions.ts
@@ -3,13 +3,21 @@ import { nextTick, ref, type Ref } from 'vue'
 
 export function useControlCategoryOptions(): {
   isOptionsOpen: Ref<boolean>
+  isOptionsClosing: Ref<boolean>
   toggleOptions: () => void
   closeOptions: () => void
+  hideOptionsImmediately: () => void
 } {
   const isOptionsOpen = ref(false)
+  const isOptionsClosing = ref(false)
 
   function toggleOptions() {
     isOptionsOpen.value = !isOptionsOpen.value
+    isOptionsClosing.value = false
+  }
+
+  function hideOptionsImmediately() {
+    isOptionsClosing.value = true
   }
 
   async function closeOptions() {
@@ -21,7 +29,9 @@ export function useControlCategoryOptions(): {
 
   return {
     isOptionsOpen,
+    isOptionsClosing,
     toggleOptions,
     closeOptions,
+    hideOptionsImmediately,
   }
 }

--- a/packages/frontend/src/components/NavigationBar/NavigationBar.vue
+++ b/packages/frontend/src/components/NavigationBar/NavigationBar.vue
@@ -52,6 +52,7 @@ const navigationLinks = [
     </div>
     <div class="flex gap-7.5">
       <Button
+        data-manage-categories-toggle
         class-to-add="bg-gray-200 px-3.5 py-1.5 rounded-md hover:bg-gray-200/50"
         @click="emit('manageCategoriesClicked')"
       >

--- a/packages/frontend/src/helpers/hooks/__tests__/useClickOutside.test.ts
+++ b/packages/frontend/src/helpers/hooks/__tests__/useClickOutside.test.ts
@@ -82,4 +82,24 @@ describe('when useClickOutside is used on a container', () => {
 
     expect(onClickOutside).not.toHaveBeenCalled()
   })
+
+  it('should not call the callback when the clicked element is removed from the DOM by its own click handler before the event finishes bubbling', async () => {
+    // Reproduces a real-browser race: a click handler on an inside element (e.g. a modal's
+    // close button) can synchronously trigger a state change whose DOM update (unmounting
+    // that element) flushes via a microtask checkpoint that runs *before* the same click
+    // event finishes bubbling to document. By the time useClickOutside's document listener
+    // runs, event.target is already detached, so a naive `container.contains(target)` check
+    // (a live DOM check) wrongly reports it as outside. composedPath() must be used instead,
+    // since it's captured at dispatch time and stays accurate regardless of DOM mutations that
+    // happen mid-bubble. jsdom does not reproduce this exact timing on its own, so it's
+    // simulated directly here by removing the element from the DOM inside its own listener.
+    const onClickOutside = vi.fn()
+    render(createClickOutsideHarness(onClickOutside, true))
+
+    const insideButton = screen.getByTestId('inside-button')
+    insideButton.addEventListener('click', () => insideButton.remove())
+    insideButton.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+    expect(onClickOutside).not.toHaveBeenCalled()
+  })
 })

--- a/packages/frontend/src/helpers/hooks/useClickOutside.ts
+++ b/packages/frontend/src/helpers/hooks/useClickOutside.ts
@@ -27,18 +27,28 @@ export interface UseClickOutsideOptions {
  * the time this listener runs — avoiding a close-then-reopen flicker that
  * `mousedown` (a separate, earlier event) would cause.
  *
+ * Uses `event.composedPath()` instead of `containerRef.value.contains(event.target)`
+ * deliberately: browsers run a microtask checkpoint after *each* bubbled listener,
+ * not just after the whole dispatch finishes. If a click's own handler (e.g. a
+ * modal's close button) synchronously changes state that causes Vue to unmount
+ * that element before the event finishes bubbling to `document`, `event.target`
+ * is already detached by the time this listener runs, and `.contains()` (a live
+ * DOM check) wrongly reports it as outside. `composedPath()` is captured at
+ * dispatch time and stays accurate regardless of DOM mutations that happen
+ * mid-bubble.
+ *
  * Pass `ignoreSelector` when the container has logical children that live
  * elsewhere in the DOM via `<Teleport>` — e.g. a dropdown or modal rendered
  * to `<body>`. Such elements aren't real DOM descendants of `containerRef`,
- * so `containerRef.value.contains(event.target)` returns false for them even
- * though a click on them shouldn't count as "outside." Mark the teleported
- * root with an attribute (e.g. `data-my-thing-portal`) and pass a matching
- * selector (e.g. `'[data-my-thing-portal]'`) to have clicks inside it ignored.
+ * so a plain containment check returns false for them even though a click on
+ * them shouldn't count as "outside." Mark the teleported root with an
+ * attribute (e.g. `data-my-thing-portal`) and pass a matching selector (e.g.
+ * `'[data-my-thing-portal]'`) to have clicks inside it ignored.
  *
- * @param containerRef - Ref to the element clicks are checked against; a click is "outside" if it (or its DOM ancestor chain) isn't this element or one of its descendants.
+ * @param containerRef - Ref to the element clicks are checked against; a click is "outside" if `containerRef.value` isn't in the click's composed path.
  * @param isActive - Called on every click; the click is ignored entirely when this returns false (e.g. pass `() => isOpen` so closed/unmounted-in-spirit containers don't react to clicks).
  * @param onClickOutside - Called once per outside click, e.g. `() => emit('close')`.
- * @param options.ignoreSelector - CSS selector; clicks landing inside a matching element are treated as "inside" even though they aren't DOM descendants of `containerRef` (for `<Teleport>`-rendered content).
+ * @param options.ignoreSelector - CSS selector; clicks whose composed path includes a matching element are treated as "inside" even though they aren't DOM descendants of `containerRef` (for `<Teleport>`-rendered content).
  */
 export function useClickOutside(
   containerRef: Ref<HTMLElement | null | undefined>,
@@ -50,20 +60,14 @@ export function useClickOutside(
     if (!isActive()) return
     const container = containerRef.value
     if (!container) return
-    const target = event.target as Node
-    if (container.contains(target)) return
-    if (options?.ignoreSelector && (target as HTMLElement).closest?.(options.ignoreSelector)) return
-    console.warn('[useClickOutside DEBUG] firing onClickOutside', {
-      target,
-      targetTag: (target as HTMLElement)?.tagName,
-      targetId: (target as HTMLElement)?.id,
-      targetClass: (target as HTMLElement)?.className,
-      container,
-      ignoreSelector: options?.ignoreSelector,
-      closestMatch: options?.ignoreSelector
-        ? (target as HTMLElement)?.closest?.(options.ignoreSelector)
-        : null,
-    })
+    const path = event.composedPath()
+    if (path.includes(container)) return
+    if (
+      options?.ignoreSelector &&
+      path.some((node) => node instanceof Element && node.matches(options.ignoreSelector!))
+    ) {
+      return
+    }
     onClickOutside()
   }
 

--- a/packages/frontend/src/helpers/hooks/useClickOutside.ts
+++ b/packages/frontend/src/helpers/hooks/useClickOutside.ts
@@ -68,19 +68,6 @@ export function useClickOutside(
     ) {
       return
     }
-    console.warn('[useClickOutside DEBUG] firing onClickOutside', {
-      target: event.target,
-      targetTag: (event.target as HTMLElement)?.tagName,
-      targetId: (event.target as HTMLElement)?.id,
-      targetClass: (event.target as HTMLElement)?.className,
-      container,
-      ignoreSelector: options?.ignoreSelector,
-      path: path.map((node) =>
-        node instanceof Element
-          ? `${node.tagName}#${node.id}.${node.className}`
-          : String(node),
-      ),
-    })
     onClickOutside()
   }
 

--- a/packages/frontend/src/helpers/hooks/useClickOutside.ts
+++ b/packages/frontend/src/helpers/hooks/useClickOutside.ts
@@ -68,6 +68,19 @@ export function useClickOutside(
     ) {
       return
     }
+    console.warn('[useClickOutside DEBUG] firing onClickOutside', {
+      target: event.target,
+      targetTag: (event.target as HTMLElement)?.tagName,
+      targetId: (event.target as HTMLElement)?.id,
+      targetClass: (event.target as HTMLElement)?.className,
+      container,
+      ignoreSelector: options?.ignoreSelector,
+      path: path.map((node) =>
+        node instanceof Element
+          ? `${node.tagName}#${node.id}.${node.className}`
+          : String(node),
+      ),
+    })
     onClickOutside()
   }
 

--- a/packages/frontend/src/helpers/hooks/useClickOutside.ts
+++ b/packages/frontend/src/helpers/hooks/useClickOutside.ts
@@ -53,6 +53,17 @@ export function useClickOutside(
     const target = event.target as Node
     if (container.contains(target)) return
     if (options?.ignoreSelector && (target as HTMLElement).closest?.(options.ignoreSelector)) return
+    console.warn('[useClickOutside DEBUG] firing onClickOutside', {
+      target,
+      targetTag: (target as HTMLElement)?.tagName,
+      targetId: (target as HTMLElement)?.id,
+      targetClass: (target as HTMLElement)?.className,
+      container,
+      ignoreSelector: options?.ignoreSelector,
+      closestMatch: options?.ignoreSelector
+        ? (target as HTMLElement)?.closest?.(options.ignoreSelector)
+        : null,
+    })
     onClickOutside()
   }
 


### PR DESCRIPTION
## Summary

PR #297 merged the initial implementation (`da39dfc`) into `dev` before these follow-up fixes were pushed, so `dev` ended up stuck on the buggiest version. This PR (replaces #300, closed) brings the full set of fixes found through manual testing into `dev`.

- **8af7495** — Panel failed to open at all: `useClickOutside` closed over a destructured `isOpen` prop, which never reflected updates after mount (stale reactive snapshot). Also excludes the `NavigationBar` toggle button from outside-click detection to stop a close-then-reopen race.
- **1337aed** — Clicking a subcategory's "⋮" options (Update SubCategory / Delete SubCategory) closed the whole panel — `SubcategoryView.vue` has its own `<Teleport to="body">` dropdown that was missing the `data-manage-categories-portal` ignore marker (only `CategoryView.vue`'s dropdown had it).
- **2155378** — Clicking a modal's own close/save button (e.g. Add Category's "X") closed the whole panel. Root cause: browsers run a microtask checkpoint after each bubbled listener, so a synchronous state change in the clicked button's own handler can unmount that element via `v-if` *before* the same click event finishes bubbling to `document`. `container.contains(event.target)` — a live DOM check — then wrongly reports the (now-detached) target as outside. Switched to `event.composedPath()`, captured at dispatch time, unaffected by mid-bubble DOM mutations.
- **4ef4adb** — The category options dropdown visibly flickered over its own just-opened modal for ~100ms (the dropdown's actual removal is intentionally delayed to protect the click gesture). Added an `isOptionsClosing` flag to hide it immediately while leaving the delayed unmount alone.
- **bf1ee93** — That flicker fix reintroduced the whole-panel-closes bug via a different mechanism: hiding the dropdown with `visibility: hidden` removes it from hit-testing, so the browser retargeted the in-flight click to `document.body`, which `composedPath()` correctly read as "outside." Switched to `opacity-0`, which hides the pixels without affecting hit-testing.

(Two intermediate commits, `33cc19c` and `8630700`, added and later removed temporary diagnostic console logging used to pinpoint the last two bugs from real browser output — no net effect.)

## Test plan
- [x] Full frontend test suite passing (`vitest run`, 386 tests)
- [x] `vue-tsc --noEmit` clean
- [x] `eslint` clean
- [x] Each fix verified with a dedicated regression test where feasible in jsdom; the two hit-testing/retargeting bugs were diagnosed from real browser console output since jsdom doesn't model that browser behavior
- [x] Manually confirmed by user across multiple rounds of testing in a real browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)