### PR TITLE
Simplify category options dropdown to match subcategory pattern

### DIFF
--- a/packages/frontend/src/components/ManageCategories/CategoryView.vue
+++ b/packages/frontend/src/components/ManageCategories/CategoryView.vue
@@ -10,6 +10,7 @@ import { useManageSubCategories } from './hooks/useManageSubcategories'
 import { useControlModal } from '../DesignSystem/Modal/useControlModal'
 import { useControlCategoryOptions } from './hooks/useControlCategoryOptions'
 import { useDropdownPosition } from '@/helpers/hooks/useDropdownPosition'
+import { useClickOutside } from '@/helpers/hooks/useClickOutside'
 import Error from '../DesignSystem/Error.vue'
 import Button from '../DesignSystem/Button/Button.vue'
 
@@ -40,10 +41,8 @@ const { isModalOpen: isUpdateCategoryModalOpen, openModal: openUpdateCategoryMod
 
 const {
   isOptionsOpen,
-  isOptionsClosing,
   toggleOptions: originalToggleOptions,
   closeOptions,
-  hideOptionsImmediately,
 } = useControlCategoryOptions()
 
 const optionsRef = ref<HTMLElement>()
@@ -51,14 +50,16 @@ const optionsDivRef = ref<HTMLElement>()
 
 const { optionsTop, optionsLeft, positionDropdown } = useDropdownPosition(optionsRef, optionsDivRef)
 
+useClickOutside(optionsDivRef, () => isOptionsOpen.value, closeOptions)
+
 async function toggleOptions() {
   originalToggleOptions()
   await positionDropdown(isOptionsOpen.value)
 }
 
-function handleOptionSelected(action: () => void) {
-  hideOptionsImmediately()
+function selectOption(action: () => void) {
   action()
+  closeOptions()
 }
 
 const showSubCategories = ref(false)
@@ -96,16 +97,13 @@ const error = deleteCategoryError || deleteSubCategoryError || updateCategoryErr
             showSubCategories ? '▼' : '▶'
           }}</span>
         </p>
-        <Button type="secondary" class="text-xs p-1!" @click="toggleOptions" @blur="closeOptions"
-          >⋮</Button
-        >
+        <Button type="secondary" class="text-xs p-1!" @click="toggleOptions">⋮</Button>
         <Teleport to="body">
           <div
             v-if="isOptionsOpen"
             ref="optionsDivRef"
             data-manage-categories-portal
             class="category-options fixed z-10000 bg-gray-50 flex flex-col gap-1 w-38 shadow-xs border"
-            :class="{ 'opacity-0': isOptionsClosing }"
             :style="{ top: optionsTop + 'px', left: optionsLeft + 'px' }"
           >
             <span
@@ -113,7 +111,7 @@ const error = deleteCategoryError || deleteSubCategoryError || updateCategoryErr
               :key="option.name"
               class="hover:bg-gray-200 px-3.5 py-1.5 rounded-md"
             >
-              <Button :key="option.name" type="text" @mousedown="handleOptionSelected(option.action)">
+              <Button :key="option.name" type="text" @click="selectOption(option.action)">
                 {{ option.name }}
               </Button>
             </span>

--- a/packages/frontend/src/components/ManageCategories/CategoryView.vue
+++ b/packages/frontend/src/components/ManageCategories/CategoryView.vue
@@ -50,7 +50,13 @@ const optionsDivRef = ref<HTMLElement>()
 
 const { optionsTop, optionsLeft, positionDropdown } = useDropdownPosition(optionsRef, optionsDivRef)
 
-useClickOutside(optionsDivRef, () => isOptionsOpen.value, closeOptions)
+// ignoreSelector on the toggle button itself is required, not optional: the click that opens
+// the dropdown is dispatched from the toggle button, which is never a DOM descendant of the
+// (freshly created) dropdown container - so without excluding it, that same click's bubble to
+// document reads as "outside" and immediately closes the dropdown it just opened.
+useClickOutside(optionsDivRef, () => isOptionsOpen.value, closeOptions, {
+  ignoreSelector: '[data-category-options-toggle]',
+})
 
 async function toggleOptions() {
   originalToggleOptions()
@@ -97,7 +103,13 @@ const error = deleteCategoryError || deleteSubCategoryError || updateCategoryErr
             showSubCategories ? '▼' : '▶'
           }}</span>
         </p>
-        <Button type="secondary" class="text-xs p-1!" @click="toggleOptions">⋮</Button>
+        <Button
+          data-category-options-toggle
+          type="secondary"
+          class="text-xs p-1!"
+          @click="toggleOptions"
+          >⋮</Button
+        >
         <Teleport to="body">
           <div
             v-if="isOptionsOpen"

--- a/packages/frontend/src/components/ManageCategories/SubcategoryView.vue
+++ b/packages/frontend/src/components/ManageCategories/SubcategoryView.vue
@@ -5,6 +5,7 @@ import Button from '../DesignSystem/Button/Button.vue'
 import UpdateNameModal from './UpdateNameModal.vue'
 import { useControlModal } from '../DesignSystem/Modal/useControlModal'
 import { useDropdownPosition } from '@/helpers/hooks/useDropdownPosition'
+import { useClickOutside } from '@/helpers/hooks/useClickOutside'
 
 const { subCategories, loading } = defineProps<{
   subCategories: ExpenseSubCategory[]
@@ -46,6 +47,8 @@ function toggleOptions(subCategoryId: string) {
 function closeOptions() {
   activeOptionsSubCategoryId.value = null
 }
+
+useClickOutside(optionsDivRef, () => !!activeOptionsSubCategoryId.value, closeOptions)
 
 function openUpdateModal(subCategory: ExpenseSubCategory) {
   selectedSubCategoryForUpdate.value = subCategory

--- a/packages/frontend/src/components/ManageCategories/SubcategoryView.vue
+++ b/packages/frontend/src/components/ManageCategories/SubcategoryView.vue
@@ -48,7 +48,13 @@ function closeOptions() {
   activeOptionsSubCategoryId.value = null
 }
 
-useClickOutside(optionsDivRef, () => !!activeOptionsSubCategoryId.value, closeOptions)
+// ignoreSelector on the toggle buttons is required, not optional: see the matching comment in
+// CategoryView.vue - the click that opens the dropdown is dispatched from a toggle button,
+// which is never a DOM descendant of the (freshly created) dropdown container, so without
+// excluding it that same click immediately closes the dropdown it just opened.
+useClickOutside(optionsDivRef, () => !!activeOptionsSubCategoryId.value, closeOptions, {
+  ignoreSelector: '[data-subcategory-options-toggle]',
+})
 
 function openUpdateModal(subCategory: ExpenseSubCategory) {
   selectedSubCategoryForUpdate.value = subCategory
@@ -80,7 +86,11 @@ const subCategoryOptions = (subCategory: ExpenseSubCategory) => [
       <div class="my-2.5">
         <span ref="optionsRef" class="relative flex items-center">
           <p style="display: inline; margin-right: 10px">{{ subCategory.name }}</p>
-          <Button type="secondary" class="text-xs p-1!" @click="toggleOptions(subCategory.id)"
+          <Button
+            data-subcategory-options-toggle
+            type="secondary"
+            class="text-xs p-1!"
+            @click="toggleOptions(subCategory.id)"
             >⋮</Button
           >
         </span>

--- a/packages/frontend/src/components/ManageCategories/__tests__/CategoryView.test.ts
+++ b/packages/frontend/src/components/ManageCategories/__tests__/CategoryView.test.ts
@@ -1,0 +1,71 @@
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { nextTick } from 'vue'
+import { describe, expect, it, vi } from 'vitest'
+import type { ExpenseCategory } from '@/types/expenseData'
+import CategoryView from '../CategoryView.vue'
+
+vi.mock('@/store/store', () => ({
+  getStore: () => ({ addCategory: vi.fn(), updateCategory: vi.fn(), deleteCategory: vi.fn() }),
+}))
+vi.mock('@/service/categories/updateCategory', () => ({
+  updateCategory: vi.fn(() => new Promise(() => {})),
+}))
+vi.mock('@/service/categories/deleteCategory', () => ({
+  deleteCategory: vi.fn(() => new Promise(() => {})),
+}))
+vi.mock('@/service/categories/addNewCategories', () => ({
+  addNewCategory: vi.fn(() => new Promise(() => {})),
+}))
+
+const category: ExpenseCategory = {
+  id: 'c1',
+  userId: 'u1',
+  accountId: 'a1',
+  name: 'Food',
+  subCategories: [],
+  createdAt: new Date(),
+  updatedAt: new Date(),
+}
+
+describe('when using the category options dropdown', () => {
+  it('should open the dropdown when clicking the options button', async () => {
+    render(CategoryView, { props: { category } })
+
+    await userEvent.click(screen.getByText('⋮'))
+
+    expect(screen.getByText('Update Category')).toBeInTheDocument()
+  })
+
+  it('should close the dropdown when clicking away from it', async () => {
+    render(CategoryView, { props: { category } })
+
+    await userEvent.click(screen.getByText('⋮'))
+    expect(screen.getByText('Update Category')).toBeInTheDocument()
+
+    document.body.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await nextTick()
+
+    expect(screen.queryByText('Update Category')).not.toBeInTheDocument()
+  })
+
+  it('should close the dropdown when selecting an option', async () => {
+    render(CategoryView, { props: { category } })
+
+    await userEvent.click(screen.getByText('⋮'))
+    await userEvent.click(screen.getByText('Update Category'))
+
+    expect(screen.queryByText('Update Category')).not.toBeInTheDocument()
+  })
+
+  it('should close the dropdown when toggling the options button again', async () => {
+    render(CategoryView, { props: { category } })
+
+    await userEvent.click(screen.getByText('⋮'))
+    expect(screen.getByText('Update Category')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByText('⋮'))
+
+    expect(screen.queryByText('Update Category')).not.toBeInTheDocument()
+  })
+})

--- a/packages/frontend/src/components/ManageCategories/hooks/__tests__/useControlCategoryOptions.test.ts
+++ b/packages/frontend/src/components/ManageCategories/hooks/__tests__/useControlCategoryOptions.test.ts
@@ -1,57 +1,47 @@
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
-import { defineComponent, nextTick } from 'vue'
+import { defineComponent } from 'vue'
 import { describe, expect, it } from 'vitest'
 import { useControlCategoryOptions } from '../useControlCategoryOptions'
 
 const ControlCategoryOptionsHarness = defineComponent({
   setup() {
-    const { isOptionsOpen, isOptionsClosing, toggleOptions, closeOptions, hideOptionsImmediately } =
-      useControlCategoryOptions()
+    const { isOptionsOpen, toggleOptions, closeOptions } = useControlCategoryOptions()
 
-    return { isOptionsOpen, isOptionsClosing, toggleOptions, closeOptions, hideOptionsImmediately }
+    return { isOptionsOpen, toggleOptions, closeOptions }
   },
   template: `<div>
-    <button data-testid="toggle" @click="toggleOptions" @blur="closeOptions">⋮</button>
-    <div v-if="isOptionsOpen" data-testid="options" :class="{ 'opacity-0': isOptionsClosing }">
-      <button data-testid="option" @mousedown="hideOptionsImmediately">Update Category</button>
+    <button data-testid="toggle" @click="toggleOptions">⋮</button>
+    <div v-if="isOptionsOpen" data-testid="options">
+      <button data-testid="option" @click="closeOptions">Update Category</button>
     </div>
   </div>`,
 })
 
 describe('when using the category options dropdown', () => {
-  it('should open the dropdown, visible and not closing', async () => {
+  it('should open the dropdown on toggle', async () => {
     render(ControlCategoryOptionsHarness)
 
     await userEvent.click(screen.getByTestId('toggle'))
 
-    const options = screen.getByTestId('options')
-    expect(options).not.toHaveClass('opacity-0')
+    expect(screen.getByTestId('options')).toBeInTheDocument()
   })
 
-  it('should hide the dropdown immediately (before it is unmounted) when an option is selected', async () => {
+  it('should close the dropdown on a second toggle', async () => {
     render(ControlCategoryOptionsHarness)
 
     await userEvent.click(screen.getByTestId('toggle'))
-    screen.getByTestId('option').dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
-    await nextTick()
-
-    const options = screen.getByTestId('options')
-    expect(options).toHaveClass('opacity-0')
-  })
-
-  it('should reset the closing state when reopened', async () => {
-    render(ControlCategoryOptionsHarness)
-
     await userEvent.click(screen.getByTestId('toggle'))
-    screen.getByTestId('option').dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
-    await nextTick()
-    expect(screen.getByTestId('options')).toHaveClass('opacity-0')
 
-    await userEvent.click(screen.getByTestId('toggle'))
     expect(screen.queryByTestId('options')).not.toBeInTheDocument()
+  })
+
+  it('should close the dropdown immediately when an option is selected', async () => {
+    render(ControlCategoryOptionsHarness)
 
     await userEvent.click(screen.getByTestId('toggle'))
-    expect(screen.getByTestId('options')).not.toHaveClass('opacity-0')
+    await userEvent.click(screen.getByTestId('option'))
+
+    expect(screen.queryByTestId('options')).not.toBeInTheDocument()
   })
 })

--- a/packages/frontend/src/components/ManageCategories/hooks/useControlCategoryOptions.ts
+++ b/packages/frontend/src/components/ManageCategories/hooks/useControlCategoryOptions.ts
@@ -1,48 +1,23 @@
-import { sleep } from '@/helpers/sleep'
-import { nextTick, ref, type Ref } from 'vue'
+import { ref, type Ref } from 'vue'
 
 export function useControlCategoryOptions(): {
   isOptionsOpen: Ref<boolean>
-  isOptionsClosing: Ref<boolean>
   toggleOptions: () => void
   closeOptions: () => void
-  hideOptionsImmediately: () => void
 } {
   const isOptionsOpen = ref(false)
-  const isOptionsClosing = ref(false)
 
   function toggleOptions() {
     isOptionsOpen.value = !isOptionsOpen.value
-    isOptionsClosing.value = false
   }
 
-  /**
-   * Set true by the consumer when an option is selected, to hide the dropdown before the
-   * 100ms delay in closeOptions() actually unmounts it (see closeOptions for why that delay
-   * exists). Bind this to an `opacity-0` class, NOT `invisible`/`visibility: hidden` or
-   * `hidden`/`display: none`: those remove the element from hit-testing, and since this flips
-   * synchronously inside the option's own `mousedown` handler, the browser can retarget the
-   * still-in-flight `mouseup`/`click` of that same gesture away from the (now unhittable)
-   * option button — observed landing on `document.body` — which useClickOutside then
-   * legitimately reads as a click outside the panel and closes it. `opacity-0` hides the
-   * pixels without touching hit-testing, so the in-flight click resolves normally.
-   */
-  function hideOptionsImmediately() {
-    isOptionsClosing.value = true
-  }
-
-  async function closeOptions() {
-    const ONE_HUNDRED_MS_TO_ALLOW_MODAL_TO_OPEN = 100
-    await sleep(ONE_HUNDRED_MS_TO_ALLOW_MODAL_TO_OPEN)
-    await nextTick()
+  function closeOptions() {
     isOptionsOpen.value = false
   }
 
   return {
     isOptionsOpen,
-    isOptionsClosing,
     toggleOptions,
     closeOptions,
-    hideOptionsImmediately,
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #301. Simplifies `CategoryView.vue`'s options dropdown ("⋮" → Update Category / Add SubCategory / Delete Category) to match `SubcategoryView.vue`'s simpler, already-correct pattern, now that `useClickOutside` (via `composedPath()`) is safe against elements disappearing mid-click.

- **e71b8c2** — Removed `CategoryView.vue`'s `mousedown`/`blur`/100ms-delayed-close dance (`isOptionsClosing`, `hideOptionsImmediately`, the `opacity-0` workaround from the previous PR) in favor of `useClickOutside`, the same robust mechanism already used to close the whole panel. Options now use plain `@click` and close the dropdown synchronously when selected. Also adds click-away-closes behavior to `SubcategoryView.vue`'s dropdown, which never had it before — both dropdowns now behave identically.
- **840bc7a** — That refactor broke *opening* the dropdown: the click that opens it originates from the "⋮" toggle button, which is never a DOM descendant of the dropdown it's about to create, so that same click's bubble to `document` read as "outside" and immediately closed it again — the same self-conflict `NavigationBar`'s panel-toggle button had. Fixed by excluding both toggle buttons (category- and subcategory-level) via `ignoreSelector`.

Net effect: simpler code (removed the opacity workaround, the artificial delay, and two extra pieces of state), and subcategory options now also close on click-away.

## Test plan
- [x] Full frontend test suite passing (`vitest run`, 390 tests)
- [x] `vue-tsc --noEmit` clean
- [x] `eslint` clean
- [x] New `CategoryView.test.ts` covering open/close-on-click-away/close-on-select/close-on-retoggle
- [x] Rewrote `useControlCategoryOptions.test.ts` for the simplified hook API
- [x] Manually confirmed by user in a real browser (jsdom does not reproduce the toggle-button self-close race, so this needed real-browser verification like the earlier fixes in #301)

🤖 Generated with [Claude Code](https://claude.com/claude-code)