### PR TITLE
SPE-43: Add category/subcategory creation directly from dropdown

### DIFF
--- a/.claude/plans/SPE-43.md
+++ b/.claude/plans/SPE-43.md
@@ -92,7 +92,7 @@ requires no new events on `GenericTable`/`TableRow` (they already pass `column` 
 
 ## Checklist
 
-- [ ] Step 1: Add `dropdownSearchable?: boolean` and
+- [x] Step 1: Add `dropdownSearchable?: boolean` and
       `onCreateOption?: (searchText: string, row: T) => Promise<string | undefined | void>` to
       `ColumnConfig<T>` in `packages/frontend/src/components/DesignSystem/Table/types.ts`.
 

--- a/.claude/plans/SPE-43.md
+++ b/.claude/plans/SPE-43.md
@@ -111,7 +111,7 @@ requires no new events on `GenericTable`/`TableRow` (they already pass `column` 
       from `Select.vue` unchanged; the search input and create button live inside that same
       teleported panel (search pinned top, list scrolls, create button pinned bottom).
 
-- [ ] Step 3: Update `Select.vue` (`packages/frontend/src/components/DropdownWithInput/Select.vue`)
+- [x] Step 3: Update `Select.vue` (`packages/frontend/src/components/DropdownWithInput/Select.vue`)
       to accept and forward new props `searchable?: boolean` and
       `onCreateOption?: (searchText: string) => Promise<string | undefined | void>` to
       `DropdownOptions.vue`, and to handle the create flow: on create-button click, call

--- a/.claude/plans/SPE-43.md
+++ b/.claude/plans/SPE-43.md
@@ -119,7 +119,7 @@ requires no new events on `GenericTable`/`TableRow` (they already pass `column` 
       `handleDropdownOptionsClick`) and close the panel; on failure keep the panel open and surface
       the error.
 
-- [ ] Step 4: Update `DropdownWithInput.vue`
+- [x] Step 4: Update `DropdownWithInput.vue`
       (`packages/frontend/src/components/DropdownWithInput/DropdownWithInput.vue`) to accept
       `searchable?: boolean` and `onCreateOption?: (...)` props and pass them through to `Select`.
 

--- a/.claude/plans/SPE-43.md
+++ b/.claude/plans/SPE-43.md
@@ -163,7 +163,7 @@ requires no new events on `GenericTable`/`TableRow` (they already pass `column` 
       add cases verifying `searchable`/`onCreateOption` props are forwarded to `Select`, and that a
       successful create result updates the model value and emits `onChange`.
 
-- [ ] Step 10: Unit tests — `TableCell.test.ts`
+- [x] Step 10: Unit tests — `TableCell.test.ts`
       (`packages/frontend/src/components/DesignSystem/Table/__tests__/TableCell.test.ts`): extend
       the existing "dropdown" describe block with cases for `column.dropdownSearchable` and
       `column.onCreateOption` being passed through to `DropdownWithInput`, and for a create-flow

--- a/.claude/plans/SPE-43.md
+++ b/.claude/plans/SPE-43.md
@@ -1,0 +1,164 @@
+# Plan: SPE-43 — Add Category/Subcategory creation from dropdown
+
+## Analysis
+
+**Dropdown stack today:** `GenericTable.vue` → `TableRow.vue` → `TableCell.vue` renders a
+`DropdownWithInput.vue` for `column.type === 'dropdown'` (options via `column.dropdownOptions`,
+static array or `(row) => string[]`). `DropdownWithInput.vue` wraps `Select.vue`, which owns
+open/close state (`isOptionsVisible`) and teleports a plain `DropdownOptions.vue` list to
+`<body>`, positioned via `useDropdownPosition`. Clicking an option (`@mousedown.stop` in
+`DropdownOptions.vue`) emits `dropdownOptionClick` → bubbles up as `onChange` → `TableCell.vue`'s
+`handleDropdownChange` sets `localValue` and immediately emits `cell:changed`. None of these
+components currently have search input or a "create new" affordance.
+
+There is an **unused** helper, `DropdownWithInput/useDropdownOptionHandlers.ts`, that already
+implements case-insensitive substring filtering (`filterListBasedOnInput`) and
+open/close (`showCategoryOptions`/`hideCategoryOptions`) state — no current component imports it.
+It's a natural starting point for the search box logic rather than writing filtering from
+scratch, though its API will need adjusting to fit the new component boundary described below.
+
+**Category/Subcategory creation already exists** as a full vertical slice, just not wired into
+the table dropdown: `ManageCategories/hooks/useAddCategory.ts` and `useAddSubCategory.ts` call
+`service/categories/addNewCategories.ts` / `addNewSubCategory.ts` (which hit the backend via
+`gateway/expenseCategory/createExpenseCategory.ts` / `gateway/expenseSubCategory/createExpenseSubCategory.ts`),
+then push the created object into the reactive store via `getStore().addCategory(...)` /
+`getStore().addSubCategory(categoryId, ...)`. This is the logic to reuse — no new
+service/gateway/backend code should be needed, only new call sites.
+
+**Where `category`/`subCategory` dropdown columns are declared:** `ExpenseDataTable.vue` (and by
+the same pattern, `IncomeDataTable.vue`, `AddExpenseTable.vue`, `AddIncomeTable.vue`) build
+`ColumnConfig[]` with `type: 'dropdown'` for `category` and `subCategory`, sourcing options from
+`useCategoriesInExpenseData()` (`categoryNames`, `getCategory`, `getSubcategories`). Subcategory
+options depend on the row's selected category and the column is `disabled` until a category is
+picked — the "create subcategory" affordance therefore needs the row's current category, not just
+free text.
+
+### Recommendation: callback prop, not an emitted event
+
+Use a **callback prop** on `ColumnConfig` (e.g. `onCreateOption?: (searchText: string, row: T) => Promise<string | undefined>`)
+rather than a DOM event emitted up through `TableCell` → `TableRow` → `GenericTable`.
+
+Reasons:
+- **Locality of return value.** Creating a category is async and the result (the newly created
+  option's name, or failure) needs to flow *back down* into the same cell to select it and close
+  the dropdown. An emitted event is fire-and-forget upward; getting a result back down would
+  require the parent to re-look-up the row/column and push a value back through props/`v-model`,
+  which is exactly the round-trip `cell:changed` already does for normal edits — reusing a
+  callback avoids inventing a second, parallel "response" channel.
+- **Per-column, not per-table.** `ColumnConfig` is already the mechanism for per-column behavior
+  (`format`, `calculate`, `disabled`, `dropdownOptions` are all functions on `ColumnConfig`). A
+  callback fits that existing shape; an event would have to be namespaced by column key
+  (`@create-option="(key, row, text) => ..."`) to disambiguate `category` vs `subCategory` in the
+  same table, adding a routing layer for no benefit since there's only ever one handler per column
+  anyway.
+- **Type safety.** A callback prop is typed end-to-end (`(searchText: string, row: T) => Promise<string | undefined>`);
+  a generic `emit('cell:create-option', ...)` payload would need runtime narrowing at the call
+  site.
+- The existing `cell:changed` emit stays as-is — it's genuinely a "something changed, tell the
+  parent" notification with no return value expected, which is the right shape for an event.
+  Creation is different because it's a request/response.
+
+### API shape for "advanced" (search + create) vs "simple" dropdown mode
+
+Add two new optional fields to `ColumnConfig<T>` (`types.ts`):
+
+```ts
+export interface ColumnConfig<T extends TableRowData = TableRowData> {
+  // ...existing fields...
+  dropdownSearchable?: boolean
+  onCreateOption?: (searchText: string, row: T) => Promise<string | undefined | void>
+}
+```
+
+- `dropdownSearchable` (default `false`/undefined = "simple" list, current behavior unchanged)
+  toggles rendering of the search input at the top of the options panel.
+- `onCreateOption` presence toggles rendering of the "Create '<text>'" button at the bottom of the
+  options panel. It's independent of `dropdownSearchable` so a column can opt into create-only or
+  search-only, but in practice `ExpenseDataTable.vue`/`IncomeDataTable.vue` will set both together
+  for `category`/`subCategory` columns. The callback returns the name to select (so the dropdown
+  can update `localValue` and emit `cell:changed`), or `undefined`/throws on failure (dropdown
+  stays open, an inline error is shown, no selection change).
+
+This mirrors the existing `dropdownOptions?: string[] | ((row: T) => string[])` pattern of putting
+all dropdown behavior on `ColumnConfig`, keeps `GenericTable.vue`'s own prop surface untouched, and
+requires no new events on `GenericTable`/`TableRow` (they already pass `column` through unchanged).
+
+## Checklist
+
+- [ ] Step 1: Add `dropdownSearchable?: boolean` and
+      `onCreateOption?: (searchText: string, row: T) => Promise<string | undefined | void>` to
+      `ColumnConfig<T>` in `packages/frontend/src/components/DesignSystem/Table/types.ts`.
+
+- [ ] Step 2: Extend `DropdownOptions.vue` (`packages/frontend/src/components/DropdownWithInput/DropdownOptions.vue`)
+      to optionally render:
+      - a search `<input>` above the options list (visible when a new `searchable` prop is true),
+        filtering the rendered `options` by case-insensitive substring match (reuse the filtering
+        logic from `useDropdownOptionHandlers.ts`, adapted to live inside this component or a
+        small composable it calls).
+      - a "Create '<searchText>'" button pinned to the bottom of the panel (visible when a new
+        `onCreate` prop/callback is provided), disabled while empty or while a creation request is
+        in flight, showing a loading/error state.
+      Keep the panel's existing `Teleport`/positioning/`max-h-[200px] overflow-y-auto` container
+      from `Select.vue` unchanged; the search input and create button live inside that same
+      teleported panel (search pinned top, list scrolls, create button pinned bottom).
+
+- [ ] Step 3: Update `Select.vue` (`packages/frontend/src/components/DropdownWithInput/Select.vue`)
+      to accept and forward new props `searchable?: boolean` and
+      `onCreateOption?: (searchText: string) => Promise<string | undefined | void>` to
+      `DropdownOptions.vue`, and to handle the create flow: on create-button click, call
+      `onCreateOption`, and on success set the returned value as the selection (same path as
+      `handleDropdownOptionsClick`) and close the panel; on failure keep the panel open and surface
+      the error.
+
+- [ ] Step 4: Update `DropdownWithInput.vue`
+      (`packages/frontend/src/components/DropdownWithInput/DropdownWithInput.vue`) to accept
+      `searchable?: boolean` and `onCreateOption?: (...)` props and pass them through to `Select`.
+
+- [ ] Step 5: Update `TableCell.vue`
+      (`packages/frontend/src/components/DesignSystem/Table/TableCell.vue`) to pass
+      `:searchable="column.dropdownSearchable"` and an `:on-create-option` binding
+      `column.onCreateOption ? (text) => column.onCreateOption!(text, row) : undefined` to
+      `DropdownWithInput`, and on a successful create result, set `localValue` and call
+      `emitCellChanged()` (mirroring `handleDropdownChange`).
+
+- [ ] Step 6: Wire up `ExpenseDataTable.vue`
+      (`packages/frontend/src/components/ExpenseDataTable/ExpenseDataTable.vue`): add
+      `dropdownSearchable: true` and `onCreateOption` to the `category` column (calling
+      `addNewCategory` + `getStore().addCategory`, reusing the logic in
+      `ManageCategories/hooks/useAddCategory.ts` — either by calling that hook's underlying
+      service/store calls directly, or by extracting a small non-hook helper function both call
+      sites can share) and to the `subCategory` column (calling `addNewSubcategory(category.id, ...)`
+      + `getStore().addSubCategory`, same reuse approach as `useAddSubCategory.ts`, guarding for
+      the case where `row.category` isn't set yet).
+
+- [ ] Step 7: Repeat step 6 for `IncomeDataTable.vue`, `AddExpenseTable.vue`, `AddIncomeTable.vue`
+      wherever they declare `category`/`subCategory` dropdown columns, for consistency (confirm
+      exact columns during implementation — noted as likely candidates from the codebase
+      exploration but not yet fully inspected).
+
+- [ ] Step 8: Unit tests — `DropdownOptions.test.ts`
+      (`packages/frontend/src/components/DropdownWithInput/__tests__/DropdownOptions.test.ts`):
+      add cases for (a) search input filters visible options by substring, (b) create button
+      renders only when `onCreate` prop is passed, (c) create button shows current search text,
+      (d) clicking create invokes the callback and shows loading/error states.
+
+- [ ] Step 9: Unit tests — `DropdownWithInput.test.ts`
+      (`packages/frontend/src/components/DropdownWithInput/__tests__/DropdownWithInput.test.ts`):
+      add cases verifying `searchable`/`onCreateOption` props are forwarded to `Select`, and that a
+      successful create result updates the model value and emits `onChange`.
+
+- [ ] Step 10: Unit tests — `TableCell.test.ts`
+      (`packages/frontend/src/components/DesignSystem/Table/__tests__/TableCell.test.ts`): extend
+      the existing "dropdown" describe block with cases for `column.dropdownSearchable` and
+      `column.onCreateOption` being passed through to `DropdownWithInput`, and for a create-flow
+      result triggering `cell:changed`.
+
+- [ ] Step 11: Unit tests — add/extend a test for `ExpenseDataTable.vue`'s category/subCategory
+      `onCreateOption` handlers (new categories append to the store and select the new value on
+      the row; new subcategories are scoped to the row's current category). Follow existing
+      colocated `__tests__` conventions and mock `service/categories/addNewCategories.ts` /
+      `addNewSubCategory.ts` + the store the way `ManageCategories/__tests__/` tests already do.
+
+- [ ] Step 12: Run the full frontend unit test suite (`vitest`) and confirm all new and existing
+      tests pass, with no behavior change for columns that don't set `dropdownSearchable`/
+      `onCreateOption` (simple mode stays pixel-for-pixel identical to today).

--- a/.claude/plans/SPE-43.md
+++ b/.claude/plans/SPE-43.md
@@ -158,7 +158,7 @@ requires no new events on `GenericTable`/`TableRow` (they already pass `column` 
       existing option (case-insensitive), (f) clicking create invokes the callback and shows
       loading/error states.
 
-- [ ] Step 9: Unit tests — `DropdownWithInput.test.ts`
+- [x] Step 9: Unit tests — `DropdownWithInput.test.ts`
       (`packages/frontend/src/components/DropdownWithInput/__tests__/DropdownWithInput.test.ts`):
       add cases verifying `searchable`/`onCreateOption` props are forwarded to `Select`, and that a
       successful create result updates the model value and emits `onChange`.

--- a/.claude/plans/SPE-43.md
+++ b/.claude/plans/SPE-43.md
@@ -35,7 +35,7 @@ free text.
 
 ### Recommendation: callback prop, not an emitted event
 
-Use a **callback prop** on `ColumnConfig` (e.g. `onCreateOption?: (searchText: string, row: T) => Promise<string | undefined>`)
+Use a **callback prop** on `ColumnConfig` (e.g. `onCreateOption?: (searchText: string, row: T) => Promise<string>`)
 rather than a DOM event emitted up through `TableCell` → `TableRow` → `GenericTable`.
 
 Reasons:
@@ -51,7 +51,7 @@ Reasons:
   (`@create-option="(key, row, text) => ..."`) to disambiguate `category` vs `subCategory` in the
   same table, adding a routing layer for no benefit since there's only ever one handler per column
   anyway.
-- **Type safety.** A callback prop is typed end-to-end (`(searchText: string, row: T) => Promise<string | undefined>`);
+- **Type safety.** A callback prop is typed end-to-end (`(searchText: string, row: T) => Promise<string>`);
   a generic `emit('cell:create-option', ...)` payload would need runtime narrowing at the call
   site.
 - The existing `cell:changed` emit stays as-is — it's genuinely a "something changed, tell the
@@ -66,7 +66,7 @@ Add two new optional fields to `ColumnConfig<T>` (`types.ts`):
 export interface ColumnConfig<T extends TableRowData = TableRowData> {
   // ...existing fields...
   dropdownSearchable?: boolean
-  onCreateOption?: (searchText: string, row: T) => Promise<string | undefined | void>
+  onCreateOption?: (searchText: string, row: T) => Promise<string>
 }
 ```
 
@@ -79,8 +79,12 @@ export interface ColumnConfig<T extends TableRowData = TableRowData> {
   button is not rendered at all (treated as a misconfiguration, not silently upgraded). In practice
   `ExpenseDataTable.vue`/`IncomeDataTable.vue` will set both together for `category`/`subCategory`
   columns. The callback returns the name to select (so the dropdown can update `localValue` and
-  emit `cell:changed`), or `undefined`/throws on failure (dropdown stays open, an inline error is
-  shown, no selection change).
+  emit `cell:changed`), or throws on failure (dropdown stays open, an inline error is shown, no
+  selection change). The signature is intentionally `Promise<string>` rather than
+  `Promise<string | undefined | void>` — the create button is only ever clickable when there's
+  non-empty, non-duplicate search text (`canCreate` in `DropdownOptions.vue`), so a "successfully
+  did nothing" return value is unreachable in practice; a genuine failure should throw instead of
+  resolving to a falsy value (see post-implementation revision below).
 - The create button is **disabled** whenever the current search text exactly matches an existing
   option (case-insensitive), since creating a duplicate isn't allowed — the button becomes
   effectively another way to select that existing option, but the safer, minimal behavior is just
@@ -93,8 +97,10 @@ requires no new events on `GenericTable`/`TableRow` (they already pass `column` 
 ## Checklist
 
 - [x] Step 1: Add `dropdownSearchable?: boolean` and
-      `onCreateOption?: (searchText: string, row: T) => Promise<string | undefined | void>` to
+      `onCreateOption?: (searchText: string, row: T) => Promise<string>` to
       `ColumnConfig<T>` in `packages/frontend/src/components/DesignSystem/Table/types.ts`.
+      (Originally implemented as `Promise<string | undefined | void>`, narrowed to
+      `Promise<string>` in a follow-up revision — see note at end of file.)
 
 - [x] Step 2: Extend `DropdownOptions.vue` (`packages/frontend/src/components/DropdownWithInput/DropdownOptions.vue`)
       to optionally render:
@@ -113,7 +119,7 @@ requires no new events on `GenericTable`/`TableRow` (they already pass `column` 
 
 - [x] Step 3: Update `Select.vue` (`packages/frontend/src/components/DropdownWithInput/Select.vue`)
       to accept and forward new props `searchable?: boolean` and
-      `onCreateOption?: (searchText: string) => Promise<string | undefined | void>` to
+      `onCreateOption?: (searchText: string) => Promise<string>` to
       `DropdownOptions.vue`, and to handle the create flow: on create-button click, call
       `onCreateOption`, and on success set the returned value as the selection (same path as
       `handleDropdownOptionsClick`) and close the panel; on failure keep the panel open and surface
@@ -180,3 +186,19 @@ requires no new events on `GenericTable`/`TableRow` (they already pass `column` 
       `onCreateOption` (simple mode stays pixel-for-pixel identical to today).
       Result: `npx vitest run` — 88 test files, 415 tests, all passing. `npx vue-tsc --noEmit`
       and `npx eslint .` both clean (only 2 pre-existing unrelated warnings in `Modal.vue`).
+
+## Post-implementation revision: `onCreateOption` return type narrowed to `Promise<string>`
+
+After the checklist above was completed, `onCreateOption` was narrowed from
+`Promise<string | undefined | void>` to `Promise<string>` across `types.ts`, `DropdownOptions.vue`,
+`Select.vue`, and `DropdownWithInput.vue`. Rationale: the create button is only ever enabled when
+`canCreate` is true (non-empty, non-duplicate search text), so callers never had a legitimate
+reason to resolve to `undefined`/`void` — a real failure should reject the promise (shown as an
+inline error, dropdown stays open) rather than silently resolving to nothing. This let
+`DropdownOptions.vue`'s `handleCreateClick` emit `optionCreated` unconditionally instead of
+guarding on truthiness, and removed now-dead blank-string guards (`if (!name) return undefined`)
+from `ExpenseDataTable.vue`'s and `AddExpenseTable.vue`'s `handleCreateCategory`/
+`handleCreateSubCategory`. Tests updated to match (dropped the "blank search string" test in
+`ExpenseDataTable.test.ts`; fixed a stale `Promise<string | undefined>` type annotation in
+`TableCell.test.ts`). Full suite re-verified: 88 files / 414 tests passing, typecheck and lint
+clean. Commit: `d39881b`.

--- a/.claude/plans/SPE-43.md
+++ b/.claude/plans/SPE-43.md
@@ -149,7 +149,7 @@ requires no new events on `GenericTable`/`TableRow` (they already pass `column` 
       `AddExpenseTable.vue` does declare `category`/`subCategory` dropdown columns and was
       updated the same way as `ExpenseDataTable.vue`.
 
-- [ ] Step 8: Unit tests — `DropdownOptions.test.ts`
+- [x] Step 8: Unit tests — `DropdownOptions.test.ts`
       (`packages/frontend/src/components/DropdownWithInput/__tests__/DropdownOptions.test.ts`):
       add cases for (a) search input filters visible options by substring, (b) create button
       renders only when both `searchable` is true and `onCreate` is passed, (c) create button does

--- a/.claude/plans/SPE-43.md
+++ b/.claude/plans/SPE-43.md
@@ -140,10 +140,14 @@ requires no new events on `GenericTable`/`TableRow` (they already pass `column` 
       + `getStore().addSubCategory`, same reuse approach as `useAddSubCategory.ts`, guarding for
       the case where `row.category` isn't set yet).
 
-- [ ] Step 7: Repeat step 6 for `IncomeDataTable.vue`, `AddExpenseTable.vue`, `AddIncomeTable.vue`
+- [x] Step 7: Repeat step 6 for `IncomeDataTable.vue`, `AddExpenseTable.vue`, `AddIncomeTable.vue`
       wherever they declare `category`/`subCategory` dropdown columns, for consistency (confirm
       exact columns during implementation — noted as likely candidates from the codebase
       exploration but not yet fully inspected).
+      Result: `IncomeDataTable.vue` and `AddIncomeTable.vue` have no category/subCategory
+      dropdown columns (income rows are date/name/amount only) — nothing to change there.
+      `AddExpenseTable.vue` does declare `category`/`subCategory` dropdown columns and was
+      updated the same way as `ExpenseDataTable.vue`.
 
 - [ ] Step 8: Unit tests — `DropdownOptions.test.ts`
       (`packages/frontend/src/components/DropdownWithInput/__tests__/DropdownOptions.test.ts`):

--- a/.claude/plans/SPE-43.md
+++ b/.claude/plans/SPE-43.md
@@ -130,7 +130,7 @@ requires no new events on `GenericTable`/`TableRow` (they already pass `column` 
       `DropdownWithInput`, and on a successful create result, set `localValue` and call
       `emitCellChanged()` (mirroring `handleDropdownChange`).
 
-- [ ] Step 6: Wire up `ExpenseDataTable.vue`
+- [x] Step 6: Wire up `ExpenseDataTable.vue`
       (`packages/frontend/src/components/ExpenseDataTable/ExpenseDataTable.vue`): add
       `dropdownSearchable: true` and `onCreateOption` to the `category` column (calling
       `addNewCategory` + `getStore().addCategory`, reusing the logic in

--- a/.claude/plans/SPE-43.md
+++ b/.claude/plans/SPE-43.md
@@ -175,6 +175,8 @@ requires no new events on `GenericTable`/`TableRow` (they already pass `column` 
       colocated `__tests__` conventions and mock `service/categories/addNewCategories.ts` /
       `addNewSubCategory.ts` + the store the way `ManageCategories/__tests__/` tests already do.
 
-- [ ] Step 12: Run the full frontend unit test suite (`vitest`) and confirm all new and existing
+- [x] Step 12: Run the full frontend unit test suite (`vitest`) and confirm all new and existing
       tests pass, with no behavior change for columns that don't set `dropdownSearchable`/
       `onCreateOption` (simple mode stays pixel-for-pixel identical to today).
+      Result: `npx vitest run` — 88 test files, 415 tests, all passing. `npx vue-tsc --noEmit`
+      and `npx eslint .` both clean (only 2 pre-existing unrelated warnings in `Modal.vue`).

--- a/.claude/plans/SPE-43.md
+++ b/.claude/plans/SPE-43.md
@@ -169,7 +169,7 @@ requires no new events on `GenericTable`/`TableRow` (they already pass `column` 
       `column.onCreateOption` being passed through to `DropdownWithInput`, and for a create-flow
       result triggering `cell:changed`.
 
-- [ ] Step 11: Unit tests — add/extend a test for `ExpenseDataTable.vue`'s category/subCategory
+- [x] Step 11: Unit tests — add/extend a test for `ExpenseDataTable.vue`'s category/subCategory
       `onCreateOption` handlers (new categories append to the store and select the new value on
       the row; new subcategories are scoped to the row's current category). Follow existing
       colocated `__tests__` conventions and mock `service/categories/addNewCategories.ts` /

--- a/.claude/plans/SPE-43.md
+++ b/.claude/plans/SPE-43.md
@@ -73,11 +73,18 @@ export interface ColumnConfig<T extends TableRowData = TableRowData> {
 - `dropdownSearchable` (default `false`/undefined = "simple" list, current behavior unchanged)
   toggles rendering of the search input at the top of the options panel.
 - `onCreateOption` presence toggles rendering of the "Create '<text>'" button at the bottom of the
-  options panel. It's independent of `dropdownSearchable` so a column can opt into create-only or
-  search-only, but in practice `ExpenseDataTable.vue`/`IncomeDataTable.vue` will set both together
-  for `category`/`subCategory` columns. The callback returns the name to select (so the dropdown
-  can update `localValue` and emit `cell:changed`), or `undefined`/throws on failure (dropdown
-  stays open, an inline error is shown, no selection change).
+  options panel, **but only when `dropdownSearchable` is also `true`**. Search-without-create is a
+  valid combination (search text just filters); create-without-search is not, since there'd be no
+  text to create from — if `onCreateOption` is set but `dropdownSearchable` is falsy, the create
+  button is not rendered at all (treated as a misconfiguration, not silently upgraded). In practice
+  `ExpenseDataTable.vue`/`IncomeDataTable.vue` will set both together for `category`/`subCategory`
+  columns. The callback returns the name to select (so the dropdown can update `localValue` and
+  emit `cell:changed`), or `undefined`/throws on failure (dropdown stays open, an inline error is
+  shown, no selection change).
+- The create button is **disabled** whenever the current search text exactly matches an existing
+  option (case-insensitive), since creating a duplicate isn't allowed — the button becomes
+  effectively another way to select that existing option, but the safer, minimal behavior is just
+  to disable it rather than repurpose its click handler.
 
 This mirrors the existing `dropdownOptions?: string[] | ((row: T) => string[])` pattern of putting
 all dropdown behavior on `ColumnConfig`, keeps `GenericTable.vue`'s own prop surface untouched, and
@@ -95,9 +102,11 @@ requires no new events on `GenericTable`/`TableRow` (they already pass `column` 
         filtering the rendered `options` by case-insensitive substring match (reuse the filtering
         logic from `useDropdownOptionHandlers.ts`, adapted to live inside this component or a
         small composable it calls).
-      - a "Create '<searchText>'" button pinned to the bottom of the panel (visible when a new
-        `onCreate` prop/callback is provided), disabled while empty or while a creation request is
-        in flight, showing a loading/error state.
+      - a "Create '<searchText>'" button pinned to the bottom of the panel, visible only when
+        `searchable` is true **and** an `onCreate` prop/callback is provided (create requires
+        search — if `onCreate` is set without `searchable`, render nothing). Disabled while the
+        search text is empty, while it exactly matches an existing option (case-insensitive — no
+        duplicate creation), or while a creation request is in flight; shows a loading/error state.
       Keep the panel's existing `Teleport`/positioning/`max-h-[200px] overflow-y-auto` container
       from `Select.vue` unchanged; the search input and create button live inside that same
       teleported panel (search pinned top, list scrolls, create button pinned bottom).
@@ -139,8 +148,11 @@ requires no new events on `GenericTable`/`TableRow` (they already pass `column` 
 - [ ] Step 8: Unit tests — `DropdownOptions.test.ts`
       (`packages/frontend/src/components/DropdownWithInput/__tests__/DropdownOptions.test.ts`):
       add cases for (a) search input filters visible options by substring, (b) create button
-      renders only when `onCreate` prop is passed, (c) create button shows current search text,
-      (d) clicking create invokes the callback and shows loading/error states.
+      renders only when both `searchable` is true and `onCreate` is passed, (c) create button does
+      NOT render when `onCreate` is passed but `searchable` is false/undefined, (d) create button
+      shows current search text, (e) create button is disabled when search text exactly matches an
+      existing option (case-insensitive), (f) clicking create invokes the callback and shows
+      loading/error states.
 
 - [ ] Step 9: Unit tests — `DropdownWithInput.test.ts`
       (`packages/frontend/src/components/DropdownWithInput/__tests__/DropdownWithInput.test.ts`):

--- a/.claude/plans/SPE-43.md
+++ b/.claude/plans/SPE-43.md
@@ -96,7 +96,7 @@ requires no new events on `GenericTable`/`TableRow` (they already pass `column` 
       `onCreateOption?: (searchText: string, row: T) => Promise<string | undefined | void>` to
       `ColumnConfig<T>` in `packages/frontend/src/components/DesignSystem/Table/types.ts`.
 
-- [ ] Step 2: Extend `DropdownOptions.vue` (`packages/frontend/src/components/DropdownWithInput/DropdownOptions.vue`)
+- [x] Step 2: Extend `DropdownOptions.vue` (`packages/frontend/src/components/DropdownWithInput/DropdownOptions.vue`)
       to optionally render:
       - a search `<input>` above the options list (visible when a new `searchable` prop is true),
         filtering the rendered `options` by case-insensitive substring match (reuse the filtering

--- a/.claude/plans/SPE-43.md
+++ b/.claude/plans/SPE-43.md
@@ -123,7 +123,7 @@ requires no new events on `GenericTable`/`TableRow` (they already pass `column` 
       (`packages/frontend/src/components/DropdownWithInput/DropdownWithInput.vue`) to accept
       `searchable?: boolean` and `onCreateOption?: (...)` props and pass them through to `Select`.
 
-- [ ] Step 5: Update `TableCell.vue`
+- [x] Step 5: Update `TableCell.vue`
       (`packages/frontend/src/components/DesignSystem/Table/TableCell.vue`) to pass
       `:searchable="column.dropdownSearchable"` and an `:on-create-option` binding
       `column.onCreateOption ? (text) => column.onCreateOption!(text, row) : undefined` to

--- a/packages/frontend/src/components/AddExpenseTable/AddExpenseTable.vue
+++ b/packages/frontend/src/components/AddExpenseTable/AddExpenseTable.vue
@@ -216,11 +216,8 @@ async function handleCellUpdate(rowIndex: number, key: keyof DisplayExpense, val
 }
 
 // Create a new category from the dropdown search text
-async function handleCreateCategory(searchText: string): Promise<string | undefined> {
-  const name = searchText.trim()
-  if (!name) return undefined
-
-  const newCategory = await addNewCategory({ name })
+async function handleCreateCategory(searchText: string): Promise<string> {
+  const newCategory = await addNewCategory({ name: searchText })
   store.addCategory(newCategory)
   return newCategory.name
 }
@@ -229,16 +226,13 @@ async function handleCreateCategory(searchText: string): Promise<string | undefi
 async function handleCreateSubCategory(
   searchText: string,
   row: DisplayExpense,
-): Promise<string | undefined> {
-  const name = searchText.trim()
-  if (!name) return undefined
-
+): Promise<string> {
   const categoryId = getCategoryId(row.category)
   if (!categoryId) {
     throw new Error('Select a category before creating a subcategory')
   }
 
-  const newSubCategory = await addNewSubcategory(categoryId, name)
+  const newSubCategory = await addNewSubcategory(categoryId, searchText)
   store.addSubCategory(categoryId, newSubCategory)
   return newSubCategory.name
 }

--- a/packages/frontend/src/components/AddExpenseTable/AddExpenseTable.vue
+++ b/packages/frontend/src/components/AddExpenseTable/AddExpenseTable.vue
@@ -13,6 +13,8 @@ import { addNewExpense } from '@/service/expenses/addNewExpense'
 import { DateFormat, formatDate } from '@/helpers/date/formatDate'
 import { useCategoriesInExpenseData } from '@/helpers/hooks/useGetCategories'
 import { watch } from 'vue'
+import { addNewCategory } from '@/service/categories/addNewCategories'
+import { addNewSubcategory } from '@/service/categories/addNewSubCategory'
 
 const newExpenses = defineModel<NewExpense[]>({ required: true })
 const props = defineProps<{
@@ -213,6 +215,34 @@ async function handleCellUpdate(rowIndex: number, key: keyof DisplayExpense, val
   }
 }
 
+// Create a new category from the dropdown search text
+async function handleCreateCategory(searchText: string): Promise<string | undefined> {
+  const name = searchText.trim()
+  if (!name) return undefined
+
+  const newCategory = await addNewCategory({ name })
+  store.addCategory(newCategory)
+  return newCategory.name
+}
+
+// Create a new subcategory scoped to the row's current category
+async function handleCreateSubCategory(
+  searchText: string,
+  row: DisplayExpense,
+): Promise<string | undefined> {
+  const name = searchText.trim()
+  if (!name) return undefined
+
+  const categoryId = getCategoryId(row.category)
+  if (!categoryId) {
+    throw new Error('Select a category before creating a subcategory')
+  }
+
+  const newSubCategory = await addNewSubcategory(categoryId, name)
+  store.addSubCategory(categoryId, newSubCategory)
+  return newSubCategory.name
+}
+
 // Move to income handler
 async function moveToIncome(row: DisplayExpense, index: number) {
   emit('moveToIncome', toModelExpense(row))
@@ -275,6 +305,8 @@ const columns = computed<ColumnConfig<DisplayExpense>[]>(() => [
     type: 'dropdown',
     required: false,
     dropdownOptions: categoryNames.value,
+    dropdownSearchable: true,
+    onCreateOption: handleCreateCategory,
   },
   {
     key: 'subCategory',
@@ -283,6 +315,8 @@ const columns = computed<ColumnConfig<DisplayExpense>[]>(() => [
     required: false,
     dropdownOptions: (row: DisplayExpense) => getSubcategories(getCategoryId(row.category)),
     disabled: (row: DisplayExpense) => !row.category,
+    dropdownSearchable: true,
+    onCreateOption: handleCreateSubCategory,
   },
 ])
 

--- a/packages/frontend/src/components/DesignSystem/Table/TableCell.vue
+++ b/packages/frontend/src/components/DesignSystem/Table/TableCell.vue
@@ -114,6 +114,13 @@ const dropdownValue = computed<string | undefined>({
 
 const shouldIncludeUncategorizedOption = computed(() => columnKey === 'category')
 
+const onCreateOption = computed(() => {
+  if (!props.column.onCreateOption) return undefined
+
+  const createOption = props.column.onCreateOption
+  return (searchText: string) => createOption(searchText, props.row)
+})
+
 const isEditable = computed(() => {
   if (props.mode === 'view') return false
   if (props.column.calculate) return false
@@ -244,6 +251,8 @@ function handleDateChange() {
         :dropdown-options="dropdownOptions"
         :include-empty-option="shouldIncludeUncategorizedOption"
         empty-option-label="Uncategorized"
+        :searchable="column.dropdownSearchable"
+        :on-create-option="onCreateOption"
         @on-change="handleDropdownChange"
         @escape-key-pressed="handleDropdownEscape"
       />

--- a/packages/frontend/src/components/DesignSystem/Table/__tests__/TableCell.test.ts
+++ b/packages/frontend/src/components/DesignSystem/Table/__tests__/TableCell.test.ts
@@ -222,7 +222,7 @@ describe('TableCell', () => {
 
       const boundCreate = wrapper.findComponent(DropdownWithInput).props('onCreateOption') as (
         searchText: string,
-      ) => Promise<string | undefined>
+      ) => Promise<string>
       await boundCreate('NewCategory')
 
       expect(onCreateOption).toHaveBeenCalledWith('NewCategory', fakeRow)

--- a/packages/frontend/src/components/DesignSystem/Table/__tests__/TableCell.test.ts
+++ b/packages/frontend/src/components/DesignSystem/Table/__tests__/TableCell.test.ts
@@ -175,6 +175,95 @@ describe('TableCell', () => {
     })
   })
 
+  describe('when column has dropdownSearchable and onCreateOption', () => {
+    it('should pass searchable through to DropdownWithInput', () => {
+      const wrapper = mountTableCell({
+        column: createColumn({
+          key: 'category',
+          label: 'Category',
+          type: 'dropdown',
+          dropdownOptions: ['Option1'],
+          dropdownSearchable: true,
+        }),
+        row: { category: 'Option1' },
+      })
+
+      expect(wrapper.findComponent(DropdownWithInput).props('searchable')).toBe(true)
+    })
+
+    it('should not pass searchable when dropdownSearchable is unset', () => {
+      const wrapper = mountTableCell({
+        column: createColumn({
+          key: 'category',
+          label: 'Category',
+          type: 'dropdown',
+          dropdownOptions: ['Option1'],
+        }),
+        row: { category: 'Option1' },
+      })
+
+      expect(wrapper.findComponent(DropdownWithInput).props('searchable')).toBeFalsy()
+    })
+
+    it('should bind onCreateOption with the current row', async () => {
+      const onCreateOption = vi.fn().mockResolvedValue('NewCategory')
+      const fakeRow = { category: 'Option1' }
+      const wrapper = mountTableCell({
+        column: createColumn({
+          key: 'category',
+          label: 'Category',
+          type: 'dropdown',
+          dropdownOptions: ['Option1'],
+          dropdownSearchable: true,
+          onCreateOption,
+        }),
+        row: fakeRow,
+      })
+
+      const boundCreate = wrapper.findComponent(DropdownWithInput).props('onCreateOption') as (
+        searchText: string,
+      ) => Promise<string | undefined>
+      await boundCreate('NewCategory')
+
+      expect(onCreateOption).toHaveBeenCalledWith('NewCategory', fakeRow)
+    })
+
+    it('should not pass onCreateOption when the column does not define one', () => {
+      const wrapper = mountTableCell({
+        column: createColumn({
+          key: 'category',
+          label: 'Category',
+          type: 'dropdown',
+          dropdownOptions: ['Option1'],
+          dropdownSearchable: true,
+        }),
+        row: { category: 'Option1' },
+      })
+
+      expect(wrapper.findComponent(DropdownWithInput).props('onCreateOption')).toBeUndefined()
+    })
+
+    it('should emit cell:changed when a new option is selected via create flow', async () => {
+      const wrapper = mountTableCell({
+        column: createColumn({
+          key: 'category',
+          label: 'Category',
+          type: 'dropdown',
+          dropdownOptions: ['Option1'],
+          dropdownSearchable: true,
+          onCreateOption: vi.fn().mockResolvedValue('NewCategory'),
+        }),
+        row: { category: 'Option1' },
+      })
+
+      const dropdown = wrapper.findComponent(DropdownWithInput)
+      await dropdown.vm.$emit('onChange', 'NewCategory')
+
+      expect(wrapper.emitted('cell:changed')).toBeTruthy()
+      expect(wrapper.emitted('cell:changed')![0]).toEqual(['category', 'NewCategory'])
+    })
+  })
+
   describe('when column.disabled is set', () => {
     it('should render as view mode when disabled is true', () => {
       const wrapper = mountTableCell({

--- a/packages/frontend/src/components/DesignSystem/Table/types.ts
+++ b/packages/frontend/src/components/DesignSystem/Table/types.ts
@@ -15,6 +15,8 @@ export interface ColumnConfig<T extends TableRowData = TableRowData> {
   disabled?: boolean | ((row: T) => boolean)
   customClass?: string
   dropdownOptions?: string[] | ((row: T) => string[])
+  dropdownSearchable?: boolean
+  onCreateOption?: (searchText: string, row: T) => Promise<string | undefined | void>
   format?: (value: unknown, row: T) => string
   calculate?: (row: T) => unknown
 }

--- a/packages/frontend/src/components/DesignSystem/Table/types.ts
+++ b/packages/frontend/src/components/DesignSystem/Table/types.ts
@@ -16,7 +16,7 @@ export interface ColumnConfig<T extends TableRowData = TableRowData> {
   customClass?: string
   dropdownOptions?: string[] | ((row: T) => string[])
   dropdownSearchable?: boolean
-  onCreateOption?: (searchText: string, row: T) => Promise<string | undefined | void>
+  onCreateOption?: (searchText: string, row: T) => Promise<string>
   format?: (value: unknown, row: T) => string
   calculate?: (row: T) => unknown
 }

--- a/packages/frontend/src/components/DropdownWithInput/DropdownOptions.vue
+++ b/packages/frontend/src/components/DropdownWithInput/DropdownOptions.vue
@@ -9,7 +9,7 @@ const { options, optionsStyle, searchable, onCreateOption } = defineProps<{
     width: string
   }
   searchable?: boolean
-  onCreateOption?: (searchText: string) => Promise<string | undefined | void>
+  onCreateOption?: (searchText: string) => Promise<string>
 }>()
 const emits = defineEmits<{
   dropdownOptionClick: [option: string]
@@ -54,9 +54,7 @@ async function handleCreateClick() {
   createError.value = undefined
   try {
     const createdValue = await onCreateOption(trimmedSearchText.value)
-    if (createdValue) {
-      emits('optionCreated', createdValue)
-    }
+    emits('optionCreated', createdValue)
   } catch (err) {
     createError.value = err instanceof Error ? err.message : 'Failed to create option'
   } finally {

--- a/packages/frontend/src/components/DropdownWithInput/DropdownOptions.vue
+++ b/packages/frontend/src/components/DropdownWithInput/DropdownOptions.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { computed, ref } from 'vue'
+import { computed, onMounted, ref, useTemplateRef } from 'vue'
 
 const { options, optionsStyle, searchable, onCreateOption } = defineProps<{
   options: string[]
@@ -19,6 +19,13 @@ const emits = defineEmits<{
 const searchText = ref('')
 const isCreating = ref(false)
 const createError = ref<string>()
+const searchInputRef = useTemplateRef<HTMLInputElement>('search-input-ref')
+
+onMounted(() => {
+  if (searchable) {
+    searchInputRef.value?.focus()
+  }
+})
 
 const trimmedSearchText = computed(() => searchText.value.trim())
 
@@ -78,6 +85,7 @@ async function handleCreateClick() {
   >
     <input
       v-if="searchable"
+      ref="search-input-ref"
       v-model="searchText"
       type="text"
       class="shrink-0 w-full px-1 mb-1 border border-gray-300 rounded-sm bg-white"

--- a/packages/frontend/src/components/DropdownWithInput/DropdownOptions.vue
+++ b/packages/frontend/src/components/DropdownWithInput/DropdownOptions.vue
@@ -43,6 +43,12 @@ const canCreate = computed(
   () => showCreateButton.value && !isSearchTextEmpty.value && !hasExactMatch.value,
 )
 
+const createButtonLabel = computed(() => {
+  if (isCreating.value) return 'Creating...'
+  if (isSearchTextEmpty.value) return ''
+  return `Create "${trimmedSearchText.value}"`
+})
+
 function optionClicked(option: string) {
   emits('dropdownOptionClick', option)
 }
@@ -67,35 +73,37 @@ async function handleCreateClick() {
 
 <template>
   <div
-    class="dropdown-options fixed z-2000 bg-white border p-1 max-h-50 overflow-y-auto shadow-xs"
+    class="dropdown-options fixed z-2000 bg-white border p-1 max-h-50 shadow-xs flex flex-col"
     :style="optionsStyle"
   >
     <input
       v-if="searchable"
       v-model="searchText"
       type="text"
-      class="sticky top-0 w-full px-1 mb-1 border border-gray-300 rounded-sm bg-white"
+      class="shrink-0 w-full px-1 mb-1 border border-gray-300 rounded-sm bg-white"
       placeholder="Search..."
       @mousedown.stop
     />
-    <div
-      v-for="option of filteredOptions"
-      :key="option"
-      class="p-1 hover:bg-gray-100/50 whitespace-normal wrap-break-word"
-      @mousedown.stop="optionClicked(option)"
-    >
-      <span>{{ option }}</span>
+    <div class="flex-1 overflow-y-auto min-h-0">
+      <div
+        v-for="option of filteredOptions"
+        :key="option"
+        class="p-1 hover:bg-gray-100/50 whitespace-normal wrap-break-word"
+        @mousedown.stop="optionClicked(option)"
+      >
+        <span>{{ option }}</span>
+      </div>
     </div>
     <button
       v-if="showCreateButton"
       type="button"
-      class="sticky bottom-0 w-full mt-1 px-1 py-0.5 text-sm text-left bg-white disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-100/50"
+      class="shrink-0 w-full mt-1 px-1 py-0.5 text-sm text-left bg-white disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-100/50"
       :disabled="!canCreate || isCreating"
       @mousedown.stop="handleCreateClick"
     >
-      {{ isCreating ? 'Creating...' : `Create "${trimmedSearchText}"` }}
+      {{ createButtonLabel }}
     </button>
-    <p v-if="createError" class="text-red-500 text-xs mt-1">{{ createError }}</p>
+    <p v-if="createError" class="shrink-0 text-red-500 text-xs mt-1">{{ createError }}</p>
   </div>
 </template>
 

--- a/packages/frontend/src/components/DropdownWithInput/DropdownOptions.vue
+++ b/packages/frontend/src/components/DropdownWithInput/DropdownOptions.vue
@@ -20,16 +20,18 @@ const searchText = ref('')
 const isCreating = ref(false)
 const createError = ref<string>()
 
+const trimmedSearchText = computed(() => searchText.value.trim())
+
+const isSearchTextEmpty = computed(() => trimmedSearchText.value === '')
+
 const filteredOptions = computed(() => {
-  if (!searchable || !searchText.value.trim()) {
+  if (!searchable || isSearchTextEmpty.value) {
     return options
   }
 
-  const query = searchText.value.trim().toLowerCase()
+  const query = trimmedSearchText.value.toLowerCase()
   return options.filter((option) => option.toLowerCase().includes(query))
 })
-
-const trimmedSearchText = computed(() => searchText.value.trim())
 
 const hasExactMatch = computed(() =>
   options.some((option) => option.toLowerCase() === trimmedSearchText.value.toLowerCase()),
@@ -38,7 +40,7 @@ const hasExactMatch = computed(() =>
 const showCreateButton = computed(() => Boolean(searchable) && Boolean(onCreateOption))
 
 const canCreate = computed(
-  () => showCreateButton.value && trimmedSearchText.value !== '' && !hasExactMatch.value,
+  () => showCreateButton.value && !isSearchTextEmpty.value && !hasExactMatch.value,
 )
 
 function optionClicked(option: string) {
@@ -65,7 +67,7 @@ async function handleCreateClick() {
 
 <template>
   <div
-    class="dropdown-options fixed z-2000 bg-white border p-1 max-h-[200px] overflow-y-auto shadow-xs"
+    class="dropdown-options fixed z-2000 bg-white border p-1 max-h-50 overflow-y-auto shadow-xs"
     :style="optionsStyle"
   >
     <input

--- a/packages/frontend/src/components/DropdownWithInput/DropdownOptions.vue
+++ b/packages/frontend/src/components/DropdownWithInput/DropdownOptions.vue
@@ -1,18 +1,67 @@
 <script lang="ts" setup>
-const { options, optionsStyle } = defineProps<{
+import { computed, ref } from 'vue'
+
+const { options, optionsStyle, searchable, onCreateOption } = defineProps<{
   options: string[]
   optionsStyle: {
     top: string
     left: string
     width: string
   }
+  searchable?: boolean
+  onCreateOption?: (searchText: string) => Promise<string | undefined | void>
 }>()
 const emits = defineEmits<{
   dropdownOptionClick: [option: string]
+  optionCreated: [value: string]
 }>()
+
+const searchText = ref('')
+const isCreating = ref(false)
+const createError = ref<string>()
+
+const filteredOptions = computed(() => {
+  if (!searchable || !searchText.value.trim()) {
+    return options
+  }
+
+  const query = searchText.value.trim().toLowerCase()
+  return options.filter((option) => option.toLowerCase().includes(query))
+})
+
+const trimmedSearchText = computed(() => searchText.value.trim())
+
+const hasExactMatch = computed(() =>
+  options.some((option) => option.toLowerCase() === trimmedSearchText.value.toLowerCase()),
+)
+
+const showCreateButton = computed(() => Boolean(searchable) && Boolean(onCreateOption))
+
+const canCreate = computed(
+  () => showCreateButton.value && trimmedSearchText.value !== '' && !hasExactMatch.value,
+)
 
 function optionClicked(option: string) {
   emits('dropdownOptionClick', option)
+}
+
+async function handleCreateClick() {
+  if (!onCreateOption || !canCreate.value || isCreating.value) {
+    return
+  }
+
+  isCreating.value = true
+  createError.value = undefined
+  try {
+    const createdValue = await onCreateOption(trimmedSearchText.value)
+    if (createdValue) {
+      emits('optionCreated', createdValue)
+    }
+  } catch (err) {
+    createError.value = err instanceof Error ? err.message : 'Failed to create option'
+  } finally {
+    isCreating.value = false
+  }
 }
 </script>
 
@@ -21,14 +70,32 @@ function optionClicked(option: string) {
     class="dropdown-options fixed z-2000 bg-white border p-1 max-h-[200px] overflow-y-auto shadow-xs"
     :style="optionsStyle"
   >
+    <input
+      v-if="searchable"
+      v-model="searchText"
+      type="text"
+      class="sticky top-0 w-full px-1 mb-1 border border-gray-300 rounded-sm bg-white"
+      placeholder="Search..."
+      @mousedown.stop
+    />
     <div
-      v-for="option of options"
+      v-for="option of filteredOptions"
       :key="option"
       class="p-1 hover:bg-gray-100/50 whitespace-normal wrap-break-word"
       @mousedown.stop="optionClicked(option)"
     >
       <span>{{ option }}</span>
     </div>
+    <button
+      v-if="showCreateButton"
+      type="button"
+      class="sticky bottom-0 w-full mt-1 px-1 py-0.5 text-sm text-left bg-white disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-100/50"
+      :disabled="!canCreate || isCreating"
+      @mousedown.stop="handleCreateClick"
+    >
+      {{ isCreating ? 'Creating...' : `Create "${trimmedSearchText}"` }}
+    </button>
+    <p v-if="createError" class="text-red-500 text-xs mt-1">{{ createError }}</p>
   </div>
 </template>
 

--- a/packages/frontend/src/components/DropdownWithInput/DropdownWithInput.vue
+++ b/packages/frontend/src/components/DropdownWithInput/DropdownWithInput.vue
@@ -9,7 +9,7 @@ const props = defineProps<{
   includeEmptyOption?: boolean
   emptyOptionLabel?: string
   searchable?: boolean
-  onCreateOption?: (searchText: string) => Promise<string | undefined | void>
+  onCreateOption?: (searchText: string) => Promise<string>
 }>()
 const emit = defineEmits<{
   onChange: [string]

--- a/packages/frontend/src/components/DropdownWithInput/DropdownWithInput.vue
+++ b/packages/frontend/src/components/DropdownWithInput/DropdownWithInput.vue
@@ -8,6 +8,8 @@ const props = defineProps<{
   autofocus?: boolean
   includeEmptyOption?: boolean
   emptyOptionLabel?: string
+  searchable?: boolean
+  onCreateOption?: (searchText: string) => Promise<string | undefined | void>
 }>()
 const emit = defineEmits<{
   onChange: [string]
@@ -44,8 +46,8 @@ function handleKey(keyboardEvent: KeyboardEvent) {
   }
 }
 
-function handleBlur() {
-  innerSelectRef.value?.hideOptions()
+function handleBlur(event: FocusEvent) {
+  innerSelectRef.value?.hideOptions(event.relatedTarget)
 }
 </script>
 
@@ -65,6 +67,8 @@ function handleBlur() {
       :dropdown-options="props.dropdownOptions"
       :include-empty-option="props.includeEmptyOption"
       :empty-option-label="props.emptyOptionLabel"
+      :searchable="props.searchable"
+      :on-create-option="props.onCreateOption"
       @on-change="handleInput"
     ></Select>
   </div>

--- a/packages/frontend/src/components/DropdownWithInput/Select.vue
+++ b/packages/frontend/src/components/DropdownWithInput/Select.vue
@@ -3,12 +3,22 @@ import { computed, nextTick, onMounted, ref } from 'vue'
 import { useDropdownPosition } from '@/helpers/hooks/useDropdownPosition'
 import DropdownOptions from './DropdownOptions.vue'
 
-const { value, dropdownOptions, autofocus, includeEmptyOption, emptyOptionLabel } = defineProps<{
+const {
+  value,
+  dropdownOptions,
+  autofocus,
+  includeEmptyOption,
+  emptyOptionLabel,
+  searchable,
+  onCreateOption,
+} = defineProps<{
   value: string | undefined
   dropdownOptions: string[]
   autofocus?: boolean
   includeEmptyOption?: boolean
   emptyOptionLabel?: string
+  searchable?: boolean
+  onCreateOption?: (searchText: string) => Promise<string | undefined | void>
 }>()
 const emit = defineEmits<{
   onChange: [option: string]
@@ -40,8 +50,22 @@ const optionsWithEmptyOption = computed(() => {
   return [emptyOptionText.value, ...dropdownOptions]
 })
 
+function getOptionsPanelElement(): HTMLElement | undefined {
+  const optionsDiv = optionsDivRef.value
+  if (optionsDiv && '$el' in optionsDiv) {
+    return optionsDiv.$el
+  }
+
+  return optionsDiv as HTMLElement | undefined
+}
+
 defineExpose({
-  hideOptions: () => {
+  hideOptions: (relatedTarget?: EventTarget | null) => {
+    const panelElement = getOptionsPanelElement()
+    if (relatedTarget && panelElement?.contains(relatedTarget as Node)) {
+      return
+    }
+
     isOptionsVisible.value = false
   },
 })
@@ -61,6 +85,12 @@ async function handleDropdownOptionsClick(option: string) {
   }
 
   emit('onChange', option)
+}
+
+async function handleOptionCreated(createdValue: string) {
+  isOptionsVisible.value = false
+  await nextTick()
+  emit('onChange', createdValue)
 }
 
 async function toggleOptionsVisibility() {
@@ -84,7 +114,10 @@ async function toggleOptionsVisibility() {
       ref="optionsDivRef"
       :options="optionsWithEmptyOption"
       :options-style="dropdownOptionsStyle"
+      :searchable="searchable"
+      :on-create-option="onCreateOption"
       @dropdown-option-click="handleDropdownOptionsClick"
+      @option-created="handleOptionCreated"
     />
   </Teleport>
 </template>

--- a/packages/frontend/src/components/DropdownWithInput/Select.vue
+++ b/packages/frontend/src/components/DropdownWithInput/Select.vue
@@ -18,7 +18,7 @@ const {
   includeEmptyOption?: boolean
   emptyOptionLabel?: string
   searchable?: boolean
-  onCreateOption?: (searchText: string) => Promise<string | undefined | void>
+  onCreateOption?: (searchText: string) => Promise<string>
 }>()
 const emit = defineEmits<{
   onChange: [option: string]

--- a/packages/frontend/src/components/DropdownWithInput/Select.vue
+++ b/packages/frontend/src/components/DropdownWithInput/Select.vue
@@ -27,7 +27,7 @@ const EMPTY_SELECTION_VALUE = ''
 const DEFAULT_EMPTY_OPTION_LABEL = 'Uncategorized'
 const isOptionsVisible = ref(Boolean(autofocus))
 const optionsRef = ref<HTMLElement>()
-const optionsDivRef = ref<HTMLElement | { $el?: HTMLElement }>()
+const optionsDivRef = ref<{ $el?: HTMLElement }>()
 
 const { optionsTop, optionsLeft, optionsWidth, positionDropdown } = useDropdownPosition(
   optionsRef,
@@ -51,12 +51,7 @@ const optionsWithEmptyOption = computed(() => {
 })
 
 function getOptionsPanelElement(): HTMLElement | undefined {
-  const optionsDiv = optionsDivRef.value
-  if (optionsDiv && '$el' in optionsDiv) {
-    return optionsDiv.$el
-  }
-
-  return optionsDiv as HTMLElement | undefined
+  return optionsDivRef.value?.$el
 }
 
 defineExpose({

--- a/packages/frontend/src/components/DropdownWithInput/Select.vue
+++ b/packages/frontend/src/components/DropdownWithInput/Select.vue
@@ -53,10 +53,6 @@ const optionsWithEmptyOption = computed(() => {
 
 const optionsPanelElement = computed(() => optionsDivRef.value?.$el)
 
-// ignoreSelector on the toggle itself is required, not optional: the click that opens the
-// dropdown is dispatched from the toggle div, which is never a DOM descendant of the (freshly
-// created, teleported) options panel - so without excluding it, that same click's bubble to
-// document reads as "outside" and immediately closes the dropdown it just opened.
 useClickOutside(
   optionsPanelElement,
   () => isOptionsVisible.value,
@@ -67,8 +63,8 @@ useClickOutside(
 )
 
 defineExpose({
-  hideOptions: (relatedTarget?: EventTarget | null) => {
-    if (relatedTarget && optionsPanelElement.value?.contains(relatedTarget as Node)) {
+  hideOptions: (elementToKeepOpenFor?: EventTarget | null) => {
+    if (elementToKeepOpenFor && optionsPanelElement.value?.contains(elementToKeepOpenFor as Node)) {
       return
     }
 

--- a/packages/frontend/src/components/DropdownWithInput/Select.vue
+++ b/packages/frontend/src/components/DropdownWithInput/Select.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, ref } from 'vue'
 import { useDropdownPosition } from '@/helpers/hooks/useDropdownPosition'
+import { useClickOutside } from '@/helpers/hooks/useClickOutside'
 import DropdownOptions from './DropdownOptions.vue'
 
 const {
@@ -50,14 +51,24 @@ const optionsWithEmptyOption = computed(() => {
   return [emptyOptionText.value, ...dropdownOptions]
 })
 
-function getOptionsPanelElement(): HTMLElement | undefined {
-  return optionsDivRef.value?.$el
-}
+const optionsPanelElement = computed(() => optionsDivRef.value?.$el)
+
+// ignoreSelector on the toggle itself is required, not optional: the click that opens the
+// dropdown is dispatched from the toggle div, which is never a DOM descendant of the (freshly
+// created, teleported) options panel - so without excluding it, that same click's bubble to
+// document reads as "outside" and immediately closes the dropdown it just opened.
+useClickOutside(
+  optionsPanelElement,
+  () => isOptionsVisible.value,
+  () => {
+    isOptionsVisible.value = false
+  },
+  { ignoreSelector: '[data-dropdown-select-toggle]' },
+)
 
 defineExpose({
   hideOptions: (relatedTarget?: EventTarget | null) => {
-    const panelElement = getOptionsPanelElement()
-    if (relatedTarget && panelElement?.contains(relatedTarget as Node)) {
+    if (relatedTarget && optionsPanelElement.value?.contains(relatedTarget as Node)) {
       return
     }
 
@@ -97,6 +108,7 @@ async function toggleOptionsVisibility() {
 <template>
   <div
     ref="optionsRef"
+    data-dropdown-select-toggle
     class="flex justify-between items-center px-2 border border-gray-500 rounded-md min-h-6"
     @click="toggleOptionsVisibility"
   >

--- a/packages/frontend/src/components/DropdownWithInput/__tests__/DropdownOptions.test.ts
+++ b/packages/frontend/src/components/DropdownWithInput/__tests__/DropdownOptions.test.ts
@@ -43,7 +43,7 @@ describe('DropdownOptions', () => {
       expect(dropdownOptionsContainer.style.top).toBe('10px')
       expect(dropdownOptionsContainer.style.left).toBe('20px')
       expect(dropdownOptionsContainer.style.width).toBe('160px')
-      expect(dropdownOptionsContainer.className).toContain('max-h-[200px]')
+      expect(dropdownOptionsContainer.className).toContain('max-h-50')
       expect(dropdownOptionsContainer.className).toContain('overflow-y-auto')
 
       const dropdownOption = screen.getByText('optionA').parentElement as HTMLElement

--- a/packages/frontend/src/components/DropdownWithInput/__tests__/DropdownOptions.test.ts
+++ b/packages/frontend/src/components/DropdownWithInput/__tests__/DropdownOptions.test.ts
@@ -1,5 +1,6 @@
-import { render, screen } from '@testing-library/vue'
+import { render, screen, waitFor } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
+import { vi } from 'vitest'
 import DropdownOptions from '../DropdownOptions.vue'
 
 describe('DropdownOptions', () => {
@@ -48,6 +49,166 @@ describe('DropdownOptions', () => {
       const dropdownOption = screen.getByText('optionA').parentElement as HTMLElement
       expect(dropdownOption.className).toContain('whitespace-normal')
       expect(dropdownOption.className).toContain('wrap-break-word')
+    })
+  })
+  describe('when searchable is false', () => {
+    it('should not render a search input', () => {
+      render(DropdownOptions, {
+        props: fakeProps,
+      })
+
+      expect(screen.queryByPlaceholderText('Search...')).toBeNull()
+    })
+
+    it('should not render a create button even if onCreateOption is provided', () => {
+      render(DropdownOptions, {
+        props: {
+          ...fakeProps,
+          onCreateOption: vi.fn(),
+        },
+      })
+
+      expect(screen.queryByRole('button')).toBeNull()
+    })
+  })
+  describe('when searchable is true', () => {
+    it('should render a search input and filter options by substring', async () => {
+      render(DropdownOptions, {
+        props: {
+          ...fakeProps,
+          searchable: true,
+        },
+      })
+
+      const searchInput = screen.getByPlaceholderText('Search...')
+      await userEvent.type(searchInput, 'A')
+
+      screen.getByText('optionA')
+      expect(screen.queryByText('optionB')).toBeNull()
+    })
+
+    it('should not render a create button when onCreateOption is not provided', () => {
+      render(DropdownOptions, {
+        props: {
+          ...fakeProps,
+          searchable: true,
+        },
+      })
+
+      expect(screen.queryByRole('button')).toBeNull()
+    })
+
+    describe('and onCreateOption is provided', () => {
+      it('should render a create button showing the current search text', async () => {
+        render(DropdownOptions, {
+          props: {
+            ...fakeProps,
+            searchable: true,
+            onCreateOption: vi.fn(),
+          },
+        })
+
+        const searchInput = screen.getByPlaceholderText('Search...')
+        await userEvent.type(searchInput, 'newOption')
+
+        screen.getByText('Create "newOption"')
+      })
+
+      it('should disable the create button when the search text is empty', () => {
+        render(DropdownOptions, {
+          props: {
+            ...fakeProps,
+            searchable: true,
+            onCreateOption: vi.fn(),
+          },
+        })
+
+        expect(screen.getByRole('button')).toBeDisabled()
+      })
+
+      it('should disable the create button when the search text matches an existing option (case-insensitive)', async () => {
+        render(DropdownOptions, {
+          props: {
+            ...fakeProps,
+            searchable: true,
+            onCreateOption: vi.fn(),
+          },
+        })
+
+        const searchInput = screen.getByPlaceholderText('Search...')
+        await userEvent.type(searchInput, 'optiona')
+
+        expect(screen.getByRole('button')).toBeDisabled()
+      })
+
+      it('should invoke the callback and emit optionCreated on success', async () => {
+        const onCreateOption = vi.fn().mockResolvedValue('newOption')
+        const { emitted } = render(DropdownOptions, {
+          props: {
+            ...fakeProps,
+            searchable: true,
+            onCreateOption,
+          },
+        })
+
+        const searchInput = screen.getByPlaceholderText('Search...')
+        await userEvent.type(searchInput, 'newOption')
+        await userEvent.click(screen.getByRole('button'))
+
+        expect(onCreateOption).toHaveBeenCalledWith('newOption')
+        await waitFor(() => {
+          expect(emitted().optionCreated).toEqual([['newOption']])
+        })
+      })
+
+      it('should show a loading state while creating and disable the button', async () => {
+        let resolveCreate!: (value: string) => void
+        const onCreateOption = vi.fn(
+          () =>
+            new Promise<string>((resolve) => {
+              resolveCreate = resolve
+            }),
+        )
+        render(DropdownOptions, {
+          props: {
+            ...fakeProps,
+            searchable: true,
+            onCreateOption,
+          },
+        })
+
+        const searchInput = screen.getByPlaceholderText('Search...')
+        await userEvent.type(searchInput, 'newOption')
+        await userEvent.click(screen.getByRole('button'))
+
+        screen.getByText('Creating...')
+        expect(screen.getByRole('button')).toBeDisabled()
+
+        resolveCreate('newOption')
+        await waitFor(() => {
+          screen.getByText('Create "newOption"')
+        })
+      })
+
+      it('should show an error message when creation fails and keep the panel usable', async () => {
+        const onCreateOption = vi.fn().mockRejectedValue(new Error('Category already exists'))
+        const { emitted } = render(DropdownOptions, {
+          props: {
+            ...fakeProps,
+            searchable: true,
+            onCreateOption,
+          },
+        })
+
+        const searchInput = screen.getByPlaceholderText('Search...')
+        await userEvent.type(searchInput, 'newOption')
+        await userEvent.click(screen.getByRole('button'))
+
+        await waitFor(() => {
+          screen.getByText('Category already exists')
+        })
+        expect(emitted().optionCreated).toBeUndefined()
+      })
     })
   })
 })

--- a/packages/frontend/src/components/DropdownWithInput/__tests__/DropdownOptions.test.ts
+++ b/packages/frontend/src/components/DropdownWithInput/__tests__/DropdownOptions.test.ts
@@ -44,11 +44,13 @@ describe('DropdownOptions', () => {
       expect(dropdownOptionsContainer.style.left).toBe('20px')
       expect(dropdownOptionsContainer.style.width).toBe('160px')
       expect(dropdownOptionsContainer.className).toContain('max-h-50')
-      expect(dropdownOptionsContainer.className).toContain('overflow-y-auto')
 
       const dropdownOption = screen.getByText('optionA').parentElement as HTMLElement
       expect(dropdownOption.className).toContain('whitespace-normal')
       expect(dropdownOption.className).toContain('wrap-break-word')
+
+      const optionsListContainer = dropdownOption.parentElement as HTMLElement
+      expect(optionsListContainer.className).toContain('overflow-y-auto')
     })
   })
   describe('when searchable is false', () => {
@@ -114,7 +116,7 @@ describe('DropdownOptions', () => {
         screen.getByText('Create "newOption"')
       })
 
-      it('should disable the create button when the search text is empty', () => {
+      it('should disable the create button and render it empty when the search text is empty', () => {
         render(DropdownOptions, {
           props: {
             ...fakeProps,
@@ -123,7 +125,9 @@ describe('DropdownOptions', () => {
           },
         })
 
-        expect(screen.getByRole('button')).toBeDisabled()
+        const createButton = screen.getByRole('button')
+        expect(createButton).toBeDisabled()
+        expect(createButton.textContent).toBe('')
       })
 
       it('should disable the create button when the search text matches an existing option (case-insensitive)', async () => {

--- a/packages/frontend/src/components/DropdownWithInput/__tests__/DropdownWithInput.test.ts
+++ b/packages/frontend/src/components/DropdownWithInput/__tests__/DropdownWithInput.test.ts
@@ -165,6 +165,19 @@ describe('DropdownWithInput', () => {
       expect(screen.queryByRole('button')).toBeTruthy()
     })
 
+    it('should autofocus the search input when the dropdown opens', async () => {
+      render(DropdownWithInput, {
+        props: {
+          dropdownOptions: ['fakeOption1', 'fakeOption2'],
+          searchable: true,
+        },
+      })
+
+      await userEvent.click(getDropdownToggleElement())
+
+      expect(screen.getByPlaceholderText('Search...')).toHaveFocus()
+    })
+
     it('should not render a create button when onCreateOption is omitted', async () => {
       render(DropdownWithInput, {
         props: {

--- a/packages/frontend/src/components/DropdownWithInput/__tests__/DropdownWithInput.test.ts
+++ b/packages/frontend/src/components/DropdownWithInput/__tests__/DropdownWithInput.test.ts
@@ -52,6 +52,21 @@ describe('DropdownWithInput', () => {
       expect(screen.queryByText('fakeOption1')).toBeNull()
     })
   })
+  describe('when a click lands outside the dropdown', () => {
+    it('should hide dropdown options', async () => {
+      render(DropdownWithInput, {
+        props: {
+          dropdownOptions: ['fakeOption1'],
+        },
+      })
+      await userEvent.click(getDropdownToggleElement())
+      screen.getByText('fakeOption1')
+
+      await userEvent.click(document.body)
+
+      expect(screen.queryByText('fakeOption1')).toBeNull()
+    })
+  })
   describe('when autofocus is enabled', () => {
     it('should show dropdown options by default', () => {
       render(DropdownWithInput, {

--- a/packages/frontend/src/components/DropdownWithInput/__tests__/DropdownWithInput.test.ts
+++ b/packages/frontend/src/components/DropdownWithInput/__tests__/DropdownWithInput.test.ts
@@ -134,6 +134,67 @@ describe('DropdownWithInput', () => {
       expect(emitted().escapeKeyPressed).toEqual([[]])
     })
   })
+  describe('when searchable and onCreateOption are provided', () => {
+    it('should forward search input and create button to the rendered options', async () => {
+      render(DropdownWithInput, {
+        props: {
+          dropdownOptions: ['fakeOption1', 'fakeOption2'],
+          searchable: true,
+          onCreateOption: vi.fn(),
+        },
+      })
+
+      await userEvent.click(getDropdownToggleElement())
+
+      screen.getByPlaceholderText('Search...')
+      expect(screen.queryByRole('button')).toBeTruthy()
+    })
+
+    it('should not render a create button when onCreateOption is omitted', async () => {
+      render(DropdownWithInput, {
+        props: {
+          dropdownOptions: ['fakeOption1', 'fakeOption2'],
+          searchable: true,
+        },
+      })
+
+      await userEvent.click(getDropdownToggleElement())
+
+      expect(screen.queryByRole('button')).toBeNull()
+    })
+
+    it('should not render a create button when searchable is omitted, even with onCreateOption set', async () => {
+      render(DropdownWithInput, {
+        props: {
+          dropdownOptions: ['fakeOption1', 'fakeOption2'],
+          onCreateOption: vi.fn(),
+        },
+      })
+
+      await userEvent.click(getDropdownToggleElement())
+
+      expect(screen.queryByRole('button')).toBeNull()
+    })
+
+    it('should update the model value and emit onChange when a new option is created', async () => {
+      const onCreateOption = vi.fn().mockResolvedValue('newOption')
+      const { emitted } = render(DropdownWithInput, {
+        props: {
+          dropdownOptions: ['fakeOption1', 'fakeOption2'],
+          searchable: true,
+          onCreateOption,
+        },
+      })
+
+      await userEvent.click(getDropdownToggleElement())
+      await userEvent.type(screen.getByPlaceholderText('Search...'), 'newOption')
+      await userEvent.click(screen.getByRole('button'))
+
+      expect(onCreateOption).toHaveBeenCalledWith('newOption')
+      expect(emitted().onChange).toEqual([['newOption']])
+      screen.getByText('newOption')
+    })
+  })
   describe('when dropdown opens near viewport boundaries', () => {
     it('should use minimum width fallback and top guard positioning', async () => {
       Object.defineProperty(window, 'innerHeight', {

--- a/packages/frontend/src/components/ExpenseDataTable/ExpenseDataTable.vue
+++ b/packages/frontend/src/components/ExpenseDataTable/ExpenseDataTable.vue
@@ -130,11 +130,8 @@ async function handleCellUpdate(rowIndex: number, key: keyof DisplayExpense, val
 }
 
 // Create a new category from the dropdown search text
-async function handleCreateCategory(searchText: string): Promise<string | undefined> {
-  const name = searchText.trim()
-  if (!name) return undefined
-
-  const newCategory = await addNewCategory({ name })
+async function handleCreateCategory(searchText: string): Promise<string> {
+  const newCategory = await addNewCategory({ name: searchText })
   store.addCategory(newCategory)
   return newCategory.name
 }
@@ -143,16 +140,13 @@ async function handleCreateCategory(searchText: string): Promise<string | undefi
 async function handleCreateSubCategory(
   searchText: string,
   row: DisplayExpense,
-): Promise<string | undefined> {
-  const name = searchText.trim()
-  if (!name) return undefined
-
+): Promise<string> {
   const category = getCategory(row.category)
   if (!category) {
     throw new Error('Select a category before creating a subcategory')
   }
 
-  const newSubCategory = await addNewSubcategory(category.id, name)
+  const newSubCategory = await addNewSubcategory(category.id, searchText)
   store.addSubCategory(category.id, newSubCategory)
   return newSubCategory.name
 }

--- a/packages/frontend/src/components/ExpenseDataTable/ExpenseDataTable.vue
+++ b/packages/frontend/src/components/ExpenseDataTable/ExpenseDataTable.vue
@@ -10,6 +10,8 @@ import { POPOVER_SYMBOL } from '@/types/providedSymbols'
 import type { PopoverRef } from '@/types/designSystem'
 import RowNotificationPopover from './hooks/RowNotificationPopover.vue'
 import { getStore } from '@/store/store'
+import { addNewCategory } from '@/service/categories/addNewCategories'
+import { addNewSubcategory } from '@/service/categories/addNewSubCategory'
 
 type DisplayExpense = Omit<Expense, 'category' | 'subCategory'> & {
   category: string
@@ -127,6 +129,34 @@ async function handleCellUpdate(rowIndex: number, key: keyof DisplayExpense, val
   }
 }
 
+// Create a new category from the dropdown search text
+async function handleCreateCategory(searchText: string): Promise<string | undefined> {
+  const name = searchText.trim()
+  if (!name) return undefined
+
+  const newCategory = await addNewCategory({ name })
+  store.addCategory(newCategory)
+  return newCategory.name
+}
+
+// Create a new subcategory scoped to the row's current category
+async function handleCreateSubCategory(
+  searchText: string,
+  row: DisplayExpense,
+): Promise<string | undefined> {
+  const name = searchText.trim()
+  if (!name) return undefined
+
+  const category = getCategory(row.category)
+  if (!category) {
+    throw new Error('Select a category before creating a subcategory')
+  }
+
+  const newSubCategory = await addNewSubcategory(category.id, name)
+  store.addSubCategory(category.id, newSubCategory)
+  return newSubCategory.name
+}
+
 // Handle row deletion
 async function handleDelete(row: DisplayExpense) {
   try {
@@ -182,6 +212,8 @@ const columns = computed<ColumnConfig<DisplayExpense>[]>(() => [
     label: 'Category',
     type: 'dropdown',
     dropdownOptions: categoryNames.value,
+    dropdownSearchable: true,
+    onCreateOption: handleCreateCategory,
   },
   {
     key: 'subCategory',
@@ -192,6 +224,8 @@ const columns = computed<ColumnConfig<DisplayExpense>[]>(() => [
       return getSubcategories(category?.id)
     },
     disabled: (row: DisplayExpense) => !row.category,
+    dropdownSearchable: true,
+    onCreateOption: handleCreateSubCategory,
   },
 ])
 

--- a/packages/frontend/src/components/ExpenseDataTable/__tests__/ExpenseDataTable.test.ts
+++ b/packages/frontend/src/components/ExpenseDataTable/__tests__/ExpenseDataTable.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { ref } from 'vue'
+import type { Store } from '@/store/storeInterface'
+import type { Expense, ExpenseCategory, ExpenseSubCategory } from '@/types/expenseData'
+import type { ColumnConfig } from '../../DesignSystem/Table'
+import { GenericTable } from '../../DesignSystem/Table'
+import { POPOVER_SYMBOL } from '@/types/providedSymbols'
+import ExpenseDataTable from '../ExpenseDataTable.vue'
+
+// --- Store mock -------------------------------------------------------------
+
+const addCategoryMock = vi.fn()
+const addSubCategoryMock = vi.fn()
+const expensesRef = ref<Expense[]>([])
+
+const mockStore = {
+  expenses: expensesRef,
+  updateExpense: vi.fn(),
+  deleteExpense: vi.fn(),
+  addCategory: addCategoryMock,
+  addSubCategory: addSubCategoryMock,
+  getAccountDetails: vi.fn(),
+} as unknown as Store
+
+vi.mock('@/store/store', () => ({
+  getStore: () => mockStore,
+}))
+
+// --- Category helpers mock ---------------------------------------------------
+
+const foodCategory: ExpenseCategory = {
+  id: 'cat-food',
+  userId: 'u1',
+  accountId: 'a1',
+  name: 'Food',
+  subCategories: [],
+  createdAt: new Date(),
+  updatedAt: new Date(),
+}
+
+const getCategoryMock = vi.fn((name: string) => (name === 'Food' ? foodCategory : undefined))
+
+vi.mock('@/helpers/hooks/useGetCategories', () => ({
+  useCategoriesInExpenseData: () => ({
+    categories: ref([]),
+    categoryNames: ref(['Food']),
+    getCategoryName: () => '',
+    getCategoryId: () => '',
+    getSubCategoryName: () => '',
+    getSubCategoryId: () => '',
+    getSubcategories: () => [],
+    getCategory: getCategoryMock,
+  }),
+}))
+
+// --- Category creation service mocks -----------------------------------------
+
+const addNewCategoryMock = vi.fn()
+vi.mock('@/service/categories/addNewCategories', () => ({
+  addNewCategory: (...args: unknown[]) => addNewCategoryMock(...args),
+}))
+
+const addNewSubcategoryMock = vi.fn()
+vi.mock('@/service/categories/addNewSubCategory', () => ({
+  addNewSubcategory: (...args: unknown[]) => addNewSubcategoryMock(...args),
+}))
+
+// -----------------------------------------------------------------------------
+
+type DisplayExpense = Omit<Expense, 'category' | 'subCategory'> & {
+  category: string
+  subCategory: string
+}
+
+function mountTable() {
+  return mount(ExpenseDataTable, {
+    global: {
+      provide: {
+        [POPOVER_SYMBOL as unknown as string]: ref({ showPopover: vi.fn() }),
+      },
+      stubs: {
+        RowNotificationPopover: true,
+      },
+    },
+  })
+}
+
+function getColumn(wrapper: ReturnType<typeof mountTable>, key: string) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const genericTable = wrapper.findComponent(GenericTable as any)
+  const columns = genericTable.props('columns') as ColumnConfig<DisplayExpense>[]
+  const column = columns.find((c) => c.key === key)
+  if (!column) {
+    throw new Error(`Column "${key}" not found`)
+  }
+  return column
+}
+
+describe('ExpenseDataTable — create category/subcategory from dropdown', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    expensesRef.value = []
+  })
+
+  describe('category column', () => {
+    it('is searchable and provides onCreateOption', () => {
+      const wrapper = mountTable()
+      const column = getColumn(wrapper, 'category')
+
+      expect(column.dropdownSearchable).toBe(true)
+      expect(column.onCreateOption).toBeDefined()
+    })
+
+    it('creates a new category and returns its name to select', async () => {
+      const newCategory: ExpenseCategory = {
+        id: 'cat-new',
+        userId: 'u1',
+        accountId: 'a1',
+        name: 'Groceries',
+        subCategories: [],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }
+      addNewCategoryMock.mockResolvedValue(newCategory)
+
+      const wrapper = mountTable()
+      const column = getColumn(wrapper, 'category')
+
+      const result = await column.onCreateOption!('Groceries', { category: '' } as DisplayExpense)
+
+      expect(addNewCategoryMock).toHaveBeenCalledWith({ name: 'Groceries' })
+      expect(addCategoryMock).toHaveBeenCalledWith(newCategory)
+      expect(result).toBe('Groceries')
+    })
+
+    it('does not call the service for a blank search string', async () => {
+      const wrapper = mountTable()
+      const column = getColumn(wrapper, 'category')
+
+      const result = await column.onCreateOption!('   ', { category: '' } as DisplayExpense)
+
+      expect(addNewCategoryMock).not.toHaveBeenCalled()
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe('subCategory column', () => {
+    it('is searchable and provides onCreateOption', () => {
+      const wrapper = mountTable()
+      const column = getColumn(wrapper, 'subCategory')
+
+      expect(column.dropdownSearchable).toBe(true)
+      expect(column.onCreateOption).toBeDefined()
+    })
+
+    it('creates a new subcategory scoped to the row current category', async () => {
+      const newSubCategory: ExpenseSubCategory = {
+        id: 'sub-new',
+        userId: 'u1',
+        accountId: 'a1',
+        name: 'Snacks',
+        categoryId: foodCategory.id,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }
+      addNewSubcategoryMock.mockResolvedValue(newSubCategory)
+
+      const wrapper = mountTable()
+      const column = getColumn(wrapper, 'subCategory')
+
+      const result = await column.onCreateOption!('Snacks', {
+        category: 'Food',
+      } as DisplayExpense)
+
+      expect(addNewSubcategoryMock).toHaveBeenCalledWith(foodCategory.id, 'Snacks')
+      expect(addSubCategoryMock).toHaveBeenCalledWith(foodCategory.id, newSubCategory)
+      expect(result).toBe('Snacks')
+    })
+
+    it('throws when the row has no category selected yet', async () => {
+      const wrapper = mountTable()
+      const column = getColumn(wrapper, 'subCategory')
+
+      await expect(
+        column.onCreateOption!('Snacks', { category: '' } as DisplayExpense),
+      ).rejects.toThrow()
+      expect(addNewSubcategoryMock).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/frontend/src/components/ExpenseDataTable/__tests__/ExpenseDataTable.test.ts
+++ b/packages/frontend/src/components/ExpenseDataTable/__tests__/ExpenseDataTable.test.ts
@@ -133,16 +133,6 @@ describe('ExpenseDataTable — create category/subcategory from dropdown', () =>
       expect(addCategoryMock).toHaveBeenCalledWith(newCategory)
       expect(result).toBe('Groceries')
     })
-
-    it('does not call the service for a blank search string', async () => {
-      const wrapper = mountTable()
-      const column = getColumn(wrapper, 'category')
-
-      const result = await column.onCreateOption!('   ', { category: '' } as DisplayExpense)
-
-      expect(addNewCategoryMock).not.toHaveBeenCalled()
-      expect(result).toBeUndefined()
-    })
   })
 
   describe('subCategory column', () => {

--- a/packages/frontend/src/components/ManageCategories/ManageCategories.vue
+++ b/packages/frontend/src/components/ManageCategories/ManageCategories.vue
@@ -48,7 +48,7 @@ onUnmounted(() => document.removeEventListener('keydown', handleKeydown))
       v-show="isOpen"
       id="manage-categories"
       ref="panelRef"
-      class="flex flex-col fixed border bg-gray-50 z-2000 p-5 top-15 right-0 h-[calc(100vh-61px)] box-border min-w-[30vw] max-w-[50vw] shadow-xl"
+      class="flex flex-col fixed border bg-gray-50 z-2000 p-5 top-nav right-0 h-[calc(100vh-61px)] box-border min-w-[30vw] max-w-[50vw] shadow-xl"
     >
       <div id="manage-categories-header" class="flex justify-between items-center mb-4">
         <h2 class="text-lg font-semibold">Your Expense Categories</h2>

--- a/packages/frontend/src/helpers/textFormatting/__tests__/toTitleCase.test.ts
+++ b/packages/frontend/src/helpers/textFormatting/__tests__/toTitleCase.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { toTitleCase } from '../toTitleCase'
+
+describe('toTitleCase', () => {
+  describe('when value is lowercase', () => {
+    it('should capitalize the first letter of each word', () => {
+      expect(toTitleCase('grocery store')).toBe('Grocery Store')
+    })
+  })
+
+  describe('when value is uppercase', () => {
+    it('should lowercase the remaining letters of each word', () => {
+      expect(toTitleCase('GROCERY STORE')).toBe('Grocery Store')
+    })
+  })
+
+  describe('when value is a single word', () => {
+    it('should capitalize just that word', () => {
+      expect(toTitleCase('utilities')).toBe('Utilities')
+    })
+  })
+
+  describe('when value has leading, trailing, or repeated whitespace', () => {
+    it('should trim and collapse whitespace between words', () => {
+      expect(toTitleCase('  credit   card  ')).toBe('Credit Card')
+    })
+  })
+
+  describe('when value is already title cased', () => {
+    it('should leave it unchanged', () => {
+      expect(toTitleCase('Eating Out')).toBe('Eating Out')
+    })
+  })
+
+  describe('when value is an empty or whitespace-only string', () => {
+    it('should return an empty string', () => {
+      expect(toTitleCase('')).toBe('')
+      expect(toTitleCase('   ')).toBe('')
+    })
+  })
+
+  describe('when a word contains an apostrophe', () => {
+    it('should only capitalize the first letter of the word', () => {
+      expect(toTitleCase("trader joe's")).toBe("Trader Joe's")
+    })
+  })
+})

--- a/packages/frontend/src/helpers/textFormatting/toTitleCase.ts
+++ b/packages/frontend/src/helpers/textFormatting/toTitleCase.ts
@@ -1,0 +1,8 @@
+export function toTitleCase(value: string): string {
+  return value
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(' ')
+}

--- a/packages/frontend/src/service/categories/__tests__/addNewCategories.test.ts
+++ b/packages/frontend/src/service/categories/__tests__/addNewCategories.test.ts
@@ -37,6 +37,16 @@ describe('when addNewCategory is called', () => {
     expect(result).toEqual(fakeExpenseCategory)
   })
 
+  it('should title case the category name before sending it to createExpenseCategory', async () => {
+    await addNewCategory({ name: 'grocery store' })
+
+    expect(mockCreateExpenseCategory).toHaveBeenCalledWith({
+      userId: fakeUserId,
+      accountId: fakeAccountId,
+      name: 'Grocery Store',
+    })
+  })
+
   it('should throw and log error if API call fails', async () => {
     const mockError = new Error('API failed')
 

--- a/packages/frontend/src/service/categories/__tests__/addNewSubcategory.test.ts
+++ b/packages/frontend/src/service/categories/__tests__/addNewSubcategory.test.ts
@@ -32,6 +32,17 @@ describe('when addNewSubcategory is called', () => {
     expect(result).toEqual(fakeExpenseSubCategory)
   })
 
+  it('should title case the subcategory name before sending it to createExpenseSubCategory', async () => {
+    await addNewSubcategory(fakeCategoryId, 'coffee shop')
+
+    expect(mockCreateExpenseSubCategory).toHaveBeenCalledWith({
+      userId: fakeUserId,
+      accountId: fakeAccountId,
+      categoryId: fakeCategoryId,
+      name: 'Coffee Shop',
+    })
+  })
+
   it('should throw and log error if API call fails', async () => {
     const mockError = new Error('API failed')
 

--- a/packages/frontend/src/service/categories/addNewCategories.ts
+++ b/packages/frontend/src/service/categories/addNewCategories.ts
@@ -1,5 +1,6 @@
 import { createExpenseCategory } from '@/gateway/expenseCategory/createExpenseCategory'
 import { getStore } from '@/store/store'
+import { toTitleCase } from '@/helpers/textFormatting/toTitleCase'
 import type { ExpenseCategory, NewExpenseCategory } from '@/types/expenseData'
 
 export async function addNewCategory(category: NewExpenseCategory): Promise<ExpenseCategory> {
@@ -8,7 +9,7 @@ export async function addNewCategory(category: NewExpenseCategory): Promise<Expe
     const request = {
       userId,
       accountId,
-      name: category.name,
+      name: toTitleCase(category.name),
     }
     return await createExpenseCategory(request)
   } catch (error) {

--- a/packages/frontend/src/service/categories/addNewSubCategory.ts
+++ b/packages/frontend/src/service/categories/addNewSubCategory.ts
@@ -1,5 +1,6 @@
 import { createExpenseSubCategory } from '@/gateway/expenseSubCategory/createExpenseSubCategory'
 import { getStore } from '@/store/store'
+import { toTitleCase } from '@/helpers/textFormatting/toTitleCase'
 import type { ExpenseSubCategory } from '@/types/expenseData'
 
 export async function addNewSubcategory(
@@ -12,7 +13,7 @@ export async function addNewSubcategory(
       userId,
       accountId,
       categoryId,
-      name: subCategoryName,
+      name: toTitleCase(subCategoryName),
     }
     return await createExpenseSubCategory(request)
   } catch (error) {


### PR DESCRIPTION
## Summary
- Adds search + inline "Create" affordance to the shared dropdown component (`DropdownWithInput`/`Select`/`DropdownOptions`), gated per-column via new `dropdownSearchable`/`onCreateOption` fields on `ColumnConfig`
- Wires category/subcategory creation into `ExpenseDataTable` and `AddExpenseTable` dropdown columns, reusing the existing `addNewCategory`/`addNewSubcategory` services and store mutations
- Create button is disabled on empty search text and on an exact (case-insensitive) match to an existing option, to prevent duplicates
- Closes the dropdown via the shared `useClickOutside` hook (same pattern as `ManageCategories`), alongside existing blur-based closing for keyboard navigation
- Centralizes category/subcategory name proper-casing (title case) in the service layer (`addNewCategory`/`addNewSubcategory`) so every create call site gets it automatically - no such normalization existed anywhere previously

## Test plan
- [x] `npx vitest run` - 89 files / 424 tests passing
- [x] `npx vue-tsc --noEmit` - clean
- [x] `npx eslint .` - clean (only 2 pre-existing unrelated warnings in `Modal.vue`)
- [x] `npx prettier --check` on touched files
- [x] Manual verification in browser (create category/subcategory from Expense table dropdowns, duplicate-prevention, click-outside/blur closing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)