### PR TITLE
SPE-43: Fix subcategory not selected after inline creation

### DIFF
--- a/packages/frontend/src/components/ExpenseDataTable/ExpenseDataTable.vue
+++ b/packages/frontend/src/components/ExpenseDataTable/ExpenseDataTable.vue
@@ -94,14 +94,14 @@ async function handleCellUpdate(rowIndex: number, key: keyof DisplayExpense, val
 
       // Clear subcategory when category changes
     } else if (key === 'subCategory') {
-      // Value is subcategory name string, need to find subcategory object for service
-      const categoryObj = updatedExpense.category
-      const subcategory = categoryObj?.subCategories?.find((sub) => sub.name === value)
-      if (subcategory) {
-        updatedExpense.subCategory = subcategory
-      } else {
-        updatedExpense.subCategory = undefined
-      }
+      // Look up the subcategory via the live categories store rather than
+      // updatedExpense.category (a snapshot from the last server response) -
+      // a subcategory just created from this same dropdown wouldn't be in
+      // that stale snapshot's subCategories list yet.
+      const categoryName = updatedExpense.category?.name
+      const category = categoryName ? getCategory(categoryName) : undefined
+      const subcategory = category?.subCategories.find((sub) => sub.name === value)
+      updatedExpense.subCategory = subcategory
     } else {
       updatedExpense = {
         ...updatedExpense,

--- a/packages/frontend/src/components/ExpenseDataTable/__tests__/ExpenseDataTable.test.ts
+++ b/packages/frontend/src/components/ExpenseDataTable/__tests__/ExpenseDataTable.test.ts
@@ -66,6 +66,11 @@ vi.mock('@/service/categories/addNewSubCategory', () => ({
   addNewSubcategory: (...args: unknown[]) => addNewSubcategoryMock(...args),
 }))
 
+const updateExpenseMock = vi.fn()
+vi.mock('@/service/expenses/updateExpense', () => ({
+  updateExpense: (...args: unknown[]) => updateExpenseMock(...args),
+}))
+
 // -----------------------------------------------------------------------------
 
 type DisplayExpense = Omit<Expense, 'category' | 'subCategory'> & {
@@ -101,6 +106,7 @@ describe('ExpenseDataTable — create category/subcategory from dropdown', () =>
   beforeEach(() => {
     vi.clearAllMocks()
     expensesRef.value = []
+    foodCategory.subCategories = []
   })
 
   describe('category column', () => {
@@ -176,6 +182,51 @@ describe('ExpenseDataTable — create category/subcategory from dropdown', () =>
         column.onCreateOption!('Snacks', { category: '' } as DisplayExpense),
       ).rejects.toThrow()
       expect(addNewSubcategoryMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('subCategory cell update after creating a new subcategory', () => {
+    it('resolves the subcategory via the live categories store, not the stale expense.category snapshot', async () => {
+      const newSubCategory: ExpenseSubCategory = {
+        id: 'sub-snacks',
+        userId: 'u1',
+        accountId: 'a1',
+        name: 'Snacks',
+        categoryId: foodCategory.id,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }
+      // The live categories store (getCategoryMock -> foodCategory) already has the
+      // subcategory that was just created via the dropdown...
+      foodCategory.subCategories = [newSubCategory]
+
+      // ...but the expense's own `.category` field is a snapshot from the last
+      // server response, taken before the subcategory existed.
+      const staleFoodCategorySnapshot: ExpenseCategory = { ...foodCategory, subCategories: [] }
+      const expense: Expense = {
+        id: 'exp-1',
+        userId: 'u1',
+        accountId: 'a1',
+        date: '2026-01-01',
+        name: 'Lunch',
+        amount: 10,
+        netAmount: 10,
+        category: staleFoodCategorySnapshot,
+        subCategory: undefined,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }
+      expensesRef.value = [expense]
+      updateExpenseMock.mockResolvedValue({ ...expense, subCategory: newSubCategory })
+
+      const wrapper = mountTable()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const genericTable = wrapper.findComponent(GenericTable as any)
+      await genericTable.vm.$emit('cell:changed', 0, 'subCategory', 'Snacks')
+
+      expect(updateExpenseMock).toHaveBeenCalledWith(
+        expect.objectContaining({ subCategory: newSubCategory }),
+      )
     })
   })
 })


### PR DESCRIPTION
## Summary
Follow-up to #305. `ExpenseDataTable`'s `handleCellUpdate` looked up the subcategory object inside `updatedExpense.category.subCategories` - a snapshot copied from the expense's own `category` field, last populated from a prior server response. A subcategory just created from the dropdown lives in the categories store's copy of the category object (mutated in place by `store.addSubCategory`), a different object reference the expense's snapshot never sees. The lookup silently missed, cleared `subCategory` to `undefined`, and the server round-trip persisted that - so the newly created option showed up in the dropdown's option list (sourced from the live store) but never landed in the select itself.

Fixed by resolving the category through `getCategory` (the same live categories-store accessor the `category` branch already uses) instead of the stale embedded snapshot.

## Test plan
- [x] Added a regression test that fails against the old code (verified locally by reverting the fix) and passes with it
- [x] `npx vitest run` - 91 files / 464 tests passing
- [x] `npx vue-tsc --noEmit` - clean
- [x] `npx eslint .` - clean (only pre-existing unrelated warnings)
- [x] `npx prettier --check` on touched files
- [x] Manual verification in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)